### PR TITLE
Integer Overflow without Warning

### DIFF
--- a/activitysim/abm/tables/skims.py
+++ b/activitysim/abm/tables/skims.py
@@ -149,7 +149,7 @@ def get_skim_info(omx_file_path, tags_to_load=None):
 def buffers_for_skims(skim_info, shared=False):
 
     skim_dtype = skim_info['dtype']
-    omx_shape = skim_info['omx_shape']
+    omx_shape = [np.float64(x) for x in skim_info['omx_shape']]
     blocks = skim_info['blocks']
 
     skim_buffers = {}


### PR DESCRIPTION
Grabbing integers from this row can result in an integer overflow without warning or error in the [buffer_size](https://github.com/ActivitySim/activitysim/blob/367d414c10d1af27ff8c2617e96d3fbea255cff4/activitysim/abm/tables/skims.py#L159) calculation below.

The issue is documented in the [Numpy](https://docs.scipy.org/doc/numpy/reference/generated/numpy.prod.html) documents:

_Arithmetic is modular when using integer types, and no error is raised on overflow. That means that, on a 32-bit platform:_
``` python
>> x = np.array([536870910, 536870910, 536870910, 536870910])
>> np.prod(x)  # random
16
```