### PR TITLE
Allow inject.add_table to replace existing

### DIFF
--- a/activitysim/core/inject.py
+++ b/activitysim/core/inject.py
@@ -84,9 +84,12 @@ def add_step(name, func):
     return orca.add_step(name, func)
 
 
-def add_table(table_name, table):
-
-    if orca.is_table(table_name) and orca.table_type(table_name) == 'dataframe':
+def add_table(table_name, table, replace=False):
+    """
+    Add new table and raise assertion error if the table already exists.
+    Silently replace if replace=True.
+    """
+    if not replace and orca.is_table(table_name) and orca.table_type(table_name) == 'dataframe':
         logger.warning("inject add_table replacing existing table %s" % table_name)
         assert False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='activitysim',
-    version='0.9',
+    version='0.9.1',
     description='Activity-Based Travel Modeling',
     author='contributing authors',
     author_email='ben.stabler@rsginc.com',


### PR DESCRIPTION
Decorated tables interfere with repop examples/tests within `populationsim`. Allow these tables to be explicitly overwritten when necessary.

Update version number to 0.9.1