### PR TITLE
Fix min inbound departure times

### DIFF
--- a/activitysim/abm/models/trip_scheduling.py
+++ b/activitysim/abm/models/trip_scheduling.py
@@ -100,7 +100,8 @@ def update_tour_earliest(trips, outbound_choices):
     ----------
     trips: pd.DataFrame
     outbound_choices: pd.Series
-        time periods depart choices, one per trip (except for trips with zero probs)
+        time periods depart choices, one per trip (except for trips with
+        zero probs)
     Returns
     -------
     modifies trips in place
@@ -110,16 +111,20 @@ def update_tour_earliest(trips, outbound_choices):
     trips['outbound_departure'] = outbound_choices.reindex(trips.index)
 
     # get max outbound trip departure times for all person-tours
-    max_outbound_person_departures = trips.groupby(['person_id', 'tour_id'])['outbound_departure'].max()
+    max_outbound_person_departures = trips.groupby(
+        ['person_id', 'tour_id'])['outbound_departure'].max()
 
     # append max outbound trip departure times to trips
-    trips['max_outbound_departure'] = list(zip(trips['person_id'], trips['tour_id']))
-    trips['max_outbound_departure'] = trips.max_outbound_departure.map(max_outbound_person_departures)
+    trips['max_outbound_departure'] = list(
+        zip(trips['person_id'], trips['tour_id']))
+    trips['max_outbound_departure'] = trips.max_outbound_departure.map(
+        max_outbound_person_departures)
 
-    # set the trips "earliest" column equal to the max outbound departure time if
-    # the max outbound departure time is greater than the current value of "earliest"
-    num_inbound = len(trips[~trips['outbound']])
-    num_updated = len(trips[(trips['earliest'] < trips['max_outbound_departure']) & (~trips['outbound'])])
+    # set the trips "earliest" column equal to the max outbound departure
+    # time if the max outbound departure time is greater than the current
+    # value of "earliest"
+    trips['earliest'] = trips[[
+        'earliest', 'max_outbound_departure']].max(axis=1)
 
 
 def clip_probs(trips, probs, model_settings):

--- a/activitysim/abm/models/util/trip.py
+++ b/activitysim/abm/models/util/trip.py
@@ -14,15 +14,10 @@ logger = logging.getLogger(__name__)
 
 def failed_trip_cohorts(trips, failed):
 
-    # outbound trips in a tour with a failed outbound trip
-    bad_outbound_trips = \
-        trips.outbound & (trips.tour_id.isin(trips.tour_id[failed & trips.outbound]))
-
-    # inbound trips in a tour with a failed inbound trip
-    bad_inbound_trips = \
-        ~trips.outbound & (trips.tour_id.isin(trips.tour_id[failed & ~trips.outbound]))
-
-    bad_trips = bad_outbound_trips | bad_inbound_trips
+    # all trips in tours with failed trips must be treated as a cohort
+    # because minimum inbound departure time depends on maximum outbound
+    # departure time.
+    bad_trips = trips.tour_id.isin(trips.tour_id[failed])
 
     return bad_trips
 


### PR DESCRIPTION
Updates to two modules to fix the issue in which the first inbound trip of a given tour is scheduled to depart prior to the last outbound trip of the tour:

- models/trip_scheduling.py -- new method to update `earliest` column in trips table after outbound trips are scheduled
- models/util/trip.py -- updates def of `failed_trip_cohorts`. cohort must include _all_ trips associated with a tour that has a failed trip because of the new interdependence between inbound and outbound departure times.