### PR TITLE
tlz (toolz switching lib) doesn't import compatibility by default

### DIFF
--- a/activitysim/core/orca.py
+++ b/activitysim/core/orca.py
@@ -982,8 +982,8 @@ def _collect_variables(names, expressions=None):
         expressions = []
     offset = len(names) - len(expressions)
     labels_map = dict(tz.concatv(
-        tz.compatibility.zip(names[:offset], names[:offset]),
-        tz.compatibility.zip(names[offset:], expressions)))
+        zip(names[:offset], names[:offset]),
+        zip(names[offset:], expressions)))
 
     all_variables = tz.merge(_INJECTABLES, _TABLES)
     variables = {}


### PR DESCRIPTION
This results in the following error

```python
>>> import tlz
>>> tlz.compatibility.zip([1,2], [3,4])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'toolz' has no attribute 'compatibility'
>>> tlz.valfilter
<function valfilter at 0x10bd30a70>
```

This could be solved by importing tlz.compability

```python
>>> import tlz.compatibility
>>> print(list(tlz.compatibility.zip([1,2], [3,4])))
[(1, 3), (2, 4)]
```

 but zip is part of the standard and the compatibility layer is being deprecated anyway, so lets just use the python core version

```bash
20200928 15:26:04 ! jamie@jamie-work-mbp:~/git
λ PYENV_VERSION=3.7.2 python -c "print(list(zip([1,2], [3,4])))"
[(1, 3), (2, 4)]
20200928 15:26:11 ! jamie@jamie-work-mbp:~/git
λ PYENV_VERSION=2.7 python -c "print(list(zip([1,2], [3,4])))"
[(1, 3), (2, 4)]
```

closes #350