### PR TITLE
Use Cython version of toolz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'pandas >= 1.1.0',
         'pyyaml >= 5.1',
         'tables >= 3.5.1',
-        'toolz >= 0.8.1',
+        'cytoolz >= 0.8.1',
         'psutil >= 4.1',
         'requests >= 2.7',
         'numba >= 0.51.2',


### PR DESCRIPTION
Usage of activitysim within popultionsim fails with missing module cytoolz - i believe that activitysim is using cytoolz internally rather than toolz. 

Referenced by @bstabler in https://github.com/ActivitySim/populationsim/pull/139