### PR TITLE
Fix numpy

### DIFF
--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -23,9 +23,9 @@ dependencies:
 - myst-parser  # allows markdown in sphinx
 - nbconvert
 - nbformat
-- numba >= 0.51.2
+- numba >= 0.56
 - numexpr
-- numpy >= 1.16.1,<=1.21
+- numpy >= 1.22
 - numpydoc
 - openmatrix >= 0.3.4.1
 - orca >= 1.6

--- a/conda-environments/activitysim-test-larch.yml
+++ b/conda-environments/activitysim-test-larch.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - python=${TRAVIS_PYTHON_VERSION}
 - pip
-- numpy >= 1.16.1,<=1.21
+- numpy >= 1.22
 - pandas >= 1.1.0
 - pyarrow >= 2.0
 - openmatrix >= 0.3.4.1
@@ -15,7 +15,7 @@ dependencies:
 - cytoolz >= 0.8.1
 - psutil >= 4.1
 - requests >= 2.7
-- numba >= 0.51.2
+- numba >= 0.56
 - orca >= 1.6
 - larch >=5.5.3
 - xarray

--- a/conda-environments/activitysim-test.yml
+++ b/conda-environments/activitysim-test.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - python=${TRAVIS_PYTHON_VERSION}
 - pip
-- numpy >= 1.16.1,<=1.21
+- numpy >= 1.22
 - pandas >= 1.1.0
 - pyarrow >= 2.0
 - openmatrix >= 0.3.4.1
@@ -15,7 +15,7 @@ dependencies:
 - cytoolz >= 0.8.1
 - psutil >= 4.1
 - requests >= 2.7
-- numba >= 0.51.2
+- numba >= 0.56
 - orca >= 1.6
 - pytest
 - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     entry_points={"console_scripts": ["activitysim=activitysim.cli.main:main"]},
     install_requires=[
         "pyarrow >= 2.0",
-        "numpy >= 1.16.1,<=1.21",
+        "numpy >= 1.22",
         "openmatrix >= 0.3.4.1",
         "pandas >= 1.1.0",
         "pyyaml >= 5.1",
@@ -37,7 +37,7 @@ setup(
         "cytoolz >= 0.8.1",
         "psutil >= 4.1",
         "requests >= 2.7",
-        "numba >= 0.51.2",
+        "numba >= 0.56",
         "orca >= 1.6",
         "simwrapper > 1.7",
     ],


### PR DESCRIPTION
Dependabot is warning of a security issue with numpy < 1.22.  To fix it we need to also upgrade to numba 0.56.  

This PR is currently erroring because numba 0.56 is [not on conda-forge yet](https://github.com/conda-forge/numba-feedstock/pull/94), it is waiting on a [llvmlite update](https://github.com/conda-forge/llvmlite-feedstock/pull/62).  

We can try this again when the dependencies are available.

