### PR TITLE
Add github workflow for windows installer creation

### DIFF
--- a/.github/workflows/build_installer.yml
+++ b/.github/workflows/build_installer.yml
@@ -1,0 +1,63 @@
+name: Build installer
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Build installer for version (e.g. "1.0.4")'
+        required: true
+        type: string
+      release:
+        description: 'Upload as release artifact'
+        required: true
+        type: boolean
+
+jobs:
+  build:
+    name: ActivitySim-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            ARCH: x86_64
+            TARGET_PLATFORM: win-64
+            OS_NAME: "Windows"
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
+      with:
+        miniconda-version: "latest"
+      if: contains(matrix.OS_NAME, 'Windows')
+
+    - name: Build installer
+      env:
+        ARCH: ${{ matrix.ARCH }}
+        OS_NAME: ${{ matrix.OS_NAME }}
+        TARGET_PLATFORM: ${{ matrix.TARGET_PLATFORM }}
+      run: |
+        export ACTIVITYSIM_VERSION=${{ inputs.version }}
+        export EXT=exe
+        source /c/Miniconda3/Scripts/activate;
+        source other_resources/installer/build_win.sh;
+        ls -alh build
+      shell: bash
+
+    - name: Upload installer to Github artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: build/Activitysim-${{ inputs.version }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}*
+        name: Activitysim-${{ inputs.version }}-${{ matrix.OS_NAME }}-${{ matrix.ARCH }}
+
+    - name: Upload installer to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: build/Activitysim*
+        tag: v${{ inputs.version }}
+        overwrite: true
+        file_glob: true
+      if: inputs.release

--- a/other_resources/installer/build.sh
+++ b/other_resources/installer/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -xe
+
+env | sort
+
+echo "***** Start: Building Activitysim installer *****"
+CONSTRUCT_ROOT="${CONSTRUCT_ROOT:-${PWD}}"
+
+cd "${CONSTRUCT_ROOT}"
+
+# Constructor should be latest for non-native building
+# See https://github.com/conda/constructor
+echo "***** Install constructor *****"
+conda install -y "constructor>=3.3.1" jinja2 curl libarchive -c conda-forge --override-channels
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    conda install -y coreutils -c conda-forge --override-channels
+fi
+# shellcheck disable=SC2154
+if [[ "${TARGET_PLATFORM}" == win-* ]]; then
+    conda install -y "nsis=3.01" -c conda-forge --override-channels
+fi
+# pip install git+git://github.com/conda/constructor@3.3.1#egg=constructor --force --no-deps
+conda list
+
+echo "***** Make temp directory *****"
+TEMP_DIR=$(mktemp -d --tmpdir=C:/Users/RUNNER~1/AppData/Local/Temp/);
+
+echo "***** Copy file for installer construction *****"
+cp -R other_resources/installer "${TEMP_DIR}/"
+cp LICENSE.txt "${TEMP_DIR}/installer/"
+
+ls -al "${TEMP_DIR}"
+
+echo "***** Construct the installer *****"
+# Transmutation requires the current directory is writable
+cd "${TEMP_DIR}"
+# shellcheck disable=SC2086
+constructor "${TEMP_DIR}/installer/" --output-dir "${TEMP_DIR}"
+cd -
+
+cd "${TEMP_DIR}"
+
+# This line will break if there is more than one installer in the folder.
+INSTALLER_PATH=$(find . -name "Activitysim*.${EXT}" | head -n 1)
+
+echo "***** Move installer to build folder *****"
+mkdir -p "${CONSTRUCT_ROOT}/build"
+mv "${INSTALLER_PATH}" "${CONSTRUCT_ROOT}/build/"
+
+echo "***** Done: Building ActivitySim installer *****"
+cd "${CONSTRUCT_ROOT}"

--- a/other_resources/installer/build_win.sh
+++ b/other_resources/installer/build_win.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+conda install posix --yes
+source other_resources/installer/build.sh

--- a/other_resources/installer/construct.yaml
+++ b/other_resources/installer/construct.yaml
@@ -1,0 +1,22 @@
+{% set version = os.environ.get("ACTIVITYSIM_VERSION", "0.42.0-0") %}
+
+name: Activitysim
+version: {{ version }}
+
+initialize_by_default: false
+register_python_default: false
+
+license_file: LICENSE.txt
+
+menu_packages: []
+
+installer_type: exe
+
+channels:
+  - conda-forge
+
+specs:
+  - python 3.9.*
+  - conda
+  - activitysim {{ version }}
+  - pip


### PR DESCRIPTION
As discussed [earlier this year](https://github.com/ActivitySim/activitysim/wiki/Project-Meeting-2022.04.14#notes), this adds a github workflow that creates a windows installer for activitysim. This installer is completely-self contained, i.e. it contains a python, activitysim and all its dependencies.

The installer is created using [constructor](https://github.com/conda/constructor/). The github workflow is based on the workflow in [miniforge](https://github.com/conda-forge/miniforge).

Constructor uses conda for installation and retrieves activitysim and its dependencies from conda-forge when the installer is 
created. Since the workflow uses conda-forge as input, a installer for a new release can be created once the release is published on conda-forge.

An example installer created with this workflow can be found here: https://github.com/Chronial/activitysim/releases/tag/v1.0.4. The installer can be improved a bit by removing some confusing options once https://github.com/conda/constructor/commit/b3ba67f9d4988f408d8ca579596af853d949127b is released.

The workflow is set up to be triggered manually via the github web interface. Once this change is merged to master, that will be available under https://github.com/ActivitySim/activitysim/actions/workflows/build_installer.yml. It is currently available in my fork under https://github.com/Chronial/activitysim/actions/workflows/build_installer.yml. I assume that only collaborators have access to that. Please tell me if I should add somebody as collaborator to my fork for evaluation purposes.