### PR TITLE
Fix for pandas 1.5

### DIFF
--- a/activitysim/abm/models/trip_matrices.py
+++ b/activitysim/abm/models/trip_matrices.py
@@ -60,7 +60,9 @@ def write_trip_matrices(network_los):
     # write matrices by zone system type
     if network_los.zone_system == los.ONE_ZONE:  # taz trips written to taz matrices
         logger.info("aggregating trips one zone...")
-        aggregate_trips = trips_df.groupby(["origin", "destination"], sort=False).sum()
+        aggregate_trips = trips_df.groupby(["origin", "destination"], sort=False).sum(
+            numeric_only=True
+        )
 
         # use the average household weight for all trips in the origin destination pair
         hh_weight_col = model_settings.get("HH_EXPANSION_WEIGHT_COL")
@@ -94,7 +96,9 @@ def write_trip_matrices(network_los):
         trips_df["dtaz"] = (
             pipeline.get_table("land_use").reindex(trips_df["destination"]).TAZ.tolist()
         )
-        aggregate_trips = trips_df.groupby(["otaz", "dtaz"], sort=False).sum()
+        aggregate_trips = trips_df.groupby(["otaz", "dtaz"], sort=False).sum(
+            numeric_only=True
+        )
 
         # use the average household weight for all trips in the origin destination pair
         hh_weight_col = model_settings.get("HH_EXPANSION_WEIGHT_COL")
@@ -130,7 +134,9 @@ def write_trip_matrices(network_los):
         trips_df["dtaz"] = (
             pipeline.get_table("land_use").reindex(trips_df["destination"]).TAZ.tolist()
         )
-        aggregate_trips = trips_df.groupby(["otaz", "dtaz"], sort=False).sum()
+        aggregate_trips = trips_df.groupby(["otaz", "dtaz"], sort=False).sum(
+            numeric_only=True
+        )
 
         # use the average household weight for all trips in the origin destination pair
         hh_weight_col = model_settings.get("HH_EXPANSION_WEIGHT_COL")
@@ -156,7 +162,9 @@ def write_trip_matrices(network_los):
         )
 
         logger.info("aggregating trips three zone tap...")
-        aggregate_trips = trips_df.groupby(["btap", "atap"], sort=False).sum()
+        aggregate_trips = trips_df.groupby(["btap", "atap"], sort=False).sum(
+            numeric_only=True
+        )
 
         # use the average household weight for all trips in the origin destination pair
         hh_weight_col = model_settings.get("HH_EXPANSION_WEIGHT_COL")

--- a/activitysim/abm/models/util/canonical_ids.py
+++ b/activitysim/abm/models/util/canonical_ids.py
@@ -1,15 +1,12 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 import logging
+import re
 
 import numpy as np
 import pandas as pd
-import re
 
-from activitysim.core.util import reindex
-from activitysim.core import config
-from activitysim.core import pipeline
-from activitysim.core import simulate
+from activitysim.core import config, simulate
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +164,7 @@ def determine_flavors_from_alts_file(
     Parameters
     ----------
     alts : pd.DataFrame
-    provided_flavors : dict
+    provided_flavors : dict, optional
         tour flavors provided by user in the model yaml
     default_flavors : dict
         default tour flavors to fall back on

--- a/activitysim/abm/models/util/test/test_flexible_tour_trip_ids.py
+++ b/activitysim/abm/models/util/test/test_flexible_tour_trip_ids.py
@@ -1,15 +1,11 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
-import os
-
 import pandas as pd
-import pandas.testing as pdt
-import pytest
 
 from ..canonical_ids import (
-    determine_mandatory_tour_flavors,
     determine_flavors_from_alts_file,
+    determine_mandatory_tour_flavors,
 )
 
 
@@ -20,7 +16,7 @@ def test_mandatory_tour_flavors():
     # first test using default
     mandatory_tour_flavors = determine_mandatory_tour_flavors(
         mtf_settings,
-        pd.DataFrame(columns={"random_name"}),
+        pd.DataFrame(columns=["random_name"]),
         default_mandatory_tour_flavors,
     )
 
@@ -69,7 +65,7 @@ def test_tour_flavors_from_alt_files():
 
     # first test using default
     tour_flavors = determine_flavors_from_alts_file(
-        pd.DataFrame(columns={"random_name"}),
+        pd.DataFrame(columns=["random_name"]),
         provided_flavors=None,
         default_flavors=default_tour_flavors,
     )

--- a/activitysim/core/config.py
+++ b/activitysim/core/config.py
@@ -635,6 +635,31 @@ def filter_warnings():
 
     warnings.filterwarnings("default", category=PerformanceWarning)
 
+    # pandas 1.5
+    # beginning in pandas version 1.5, a new warning is emitted when a column is set via iloc
+    # from an array of different dtype, the update will eventually be done in-place in future
+    # versions. This is actually the preferred outcome for ActivitySim and no code changes are
+    # needed.
+    warnings.filterwarnings(
+        "ignore",
+        category=FutureWarning,
+        message=(
+            ".*will attempt to set the values inplace instead of always setting a new array. "
+            "To retain the old behavior, use either.*"
+        ),
+    )
+
+    # beginning in sharrow version 2.5, a CacheMissWarning is emitted when a sharrow
+    # flow cannot be loaded from cache and needs to be compiled.  These are performance
+    # warnings for production runs and totally expected when running test or on new
+    # machines
+    try:
+        from sharrow import CacheMissWarning
+    except ImportError:
+        pass
+    else:
+        warnings.filterwarnings("default", category=CacheMissWarning)
+
 
 def handle_standard_args(parser=None):
 

--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -23,9 +23,9 @@ dependencies:
 - myst-parser  # allows markdown in sphinx
 - nbconvert
 - nbformat
-- numba >= 0.51.2
+- numba >= 0.56.4
 - numexpr
-- numpy >= 1.16.1,<=1.21
+- numpy >= 1.16.1
 - numpydoc
 - openmatrix >= 0.3.4.1
 - orca >= 1.6

--- a/conda-environments/activitysim-test-larch.yml
+++ b/conda-environments/activitysim-test-larch.yml
@@ -12,8 +12,8 @@ dependencies:
 - isort
 - larch >=5.5.3
 - nbmake
-- numba >= 0.55.2
-- numpy >= 1.16.1,<=1.21
+- numba >= 0.56.4
+- numpy >= 1.16.1
 - openmatrix >= 0.3.4.1
 - orca >= 1.6
 - pandas >= 1.1.0

--- a/conda-environments/activitysim-test.yml
+++ b/conda-environments/activitysim-test.yml
@@ -10,8 +10,8 @@ dependencies:
 - cytoolz >= 0.8.1
 - isort
 - nbmake
-- numba >= 0.55.2
-- numpy >= 1.16.1,<=1.21
+- numba >= 0.56.4
+- numpy >= 1.16.1
 - openmatrix >= 0.3.4.1
 - orca >= 1.6
 - pandas >= 1.1.0

--- a/conda-environments/docbuild.yml
+++ b/conda-environments/docbuild.yml
@@ -25,8 +25,8 @@ dependencies:
 - larch >=5.5.3
 - matplotlib
 - myst-parser
-- numba >= 0.51.2
-- numpy >= 1.16.1,<=1.21
+- numba >= 0.56.4
+- numpy >= 1.16.1
 - numpydoc
 - openmatrix >= 0.3.4.1
 - orca >= 1.6

--- a/conda-environments/github-actions-tests.yml
+++ b/conda-environments/github-actions-tests.yml
@@ -16,7 +16,7 @@ dependencies:
 - numpy >= 1.16.1
 - openmatrix >= 0.3.4.1
 - orca >= 1.6
-- pandas >= 1.1.0,<1.5
+- pandas >= 1.1.0
 - psutil >= 4.1
 - pyarrow >= 2.0
 - pypyr >= 5.3

--- a/conda-environments/github-actions-tests.yml
+++ b/conda-environments/github-actions-tests.yml
@@ -12,8 +12,8 @@ dependencies:
 - cytoolz >= 0.8.1
 - isort
 - nbmake
-- numba = 0.55.2  # see https://github.com/conda-forge/numba-feedstock/pull/104
-- numpy >= 1.16.1,<=1.21
+- numba >= 0.56.4
+- numpy >= 1.16.1
 - openmatrix >= 0.3.4.1
 - orca >= 1.6
 - pandas >= 1.1.0,<1.5


### PR DESCRIPTION
In pandas 1.5 there is a new `FutureWarning` emitted when a column is set via iloc from an array of different dtype.  In a future pandas, the update will eventually be done in-place.  This is actually the preferred outcome for ActivitySim and no "real" code changes are needed.  But some of our tests treat unexpected warnings as errors.  To address this, we mark this particular warning as expected.

Also, an upcoming Sharrow update will begin emitting `CacheMissWarning` when the compiler needs to be invoked.  This too is completely normal in some circumstances (including in many tests) so it too is marked as an expected warning.
