### PR TITLE
docs: correct the unit of `chunk_size`.

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -616,7 +616,7 @@ Chunking management.
    of chunk_size simplifies model setup since it is the approximate amount of RAM available to
    ActivitySim as opposed to the obscure number of doubles (64-bit numbers) in a chunk of a choosers table.
 
-The ``chunk_size`` is the approximate amount of RAM in GBs to allocate to ActivitySim for batch
+The ``chunk_size`` is the approximate amount of RAM in bytes (1 Gigabyte or 1 GB is equal to 1,000,000,000 bytes) to allocate to ActivitySim for batch
 processing choosers across all processes.  It is specified in bytes, for example ``chunk_size: 500_000_000_000`` is 500 GBs.
 If set ``chunk_training_mode: disabled`` then no chunking will be performed and ActivitySim will attempt to solve all the
 choosers at once across all the processes.  Chunking is required when all the chooser data required to process all the


### PR DESCRIPTION
rebases #623 onto develop