### PR TITLE
Black 2022 style

### DIFF
--- a/conda-environments/activitysim-dev-base.yml
+++ b/conda-environments/activitysim-dev-base.yml
@@ -16,7 +16,7 @@ dependencies:
 - python=3.9
 - pip
 - asv  # for benchmarking
-- black
+- black >= 22.0,<23
 - bump2version  # for making a release
 - coveralls
 - cytoolz >= 0.8.1

--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - python=3.9
 - pip
 - asv  # for benchmarking
-- black
+- black >= 22.0,<23
 - bump2version  # for making a release
 - coveralls
 - cytoolz >= 0.8.1

--- a/conda-environments/docbuild.yml
+++ b/conda-environments/docbuild.yml
@@ -12,7 +12,7 @@ channels:
 dependencies:
 - python=3.9
 - pip
-- black
+- black >= 22.0,<23
 - bump2version
 - coveralls
 - cytoolz >= 0.8.1

--- a/conda-environments/github-actions-tests.yml
+++ b/conda-environments/github-actions-tests.yml
@@ -7,7 +7,7 @@ channels:
 - conda-forge
 dependencies:
 - pip
-- black
+- black >= 22.0,<23
 - coveralls
 - cytoolz >= 0.8.1
 - isort

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -190,8 +190,14 @@ ActivitySim includes a :ref:`cli` for creating examples and running the model.
 To setup and run the primary example (see :ref:`examples`), do the following:
 
 * Open a command prompt
-* Activate the conda environment with ActivitySim installed (i.e. ``conda activate asim``)
-* Type ``activitysim create -e prototype_mtc -d test_prototype_mtc`` to copy the very small prototype_mtc example to a new test_prototype_mtc directory
+* If you installed ActivitySim using conda environments, activate the conda
+  environment with ActivitySim installed (i.e. ``conda activate asim``)
+* Or, if you used the :ref:`pre-packaged installer<Pre-packaged Installer>`,
+  replace all the commands below that call ``activitysim ...`` with the complete
+  path to your installed location, which is probably something
+  like ``c:\programdata\activitysim\scripts\activitysim.exe``.
+* Type ``activitysim create -e prototype_mtc -d test_prototype_mtc`` to copy
+  the very small prototype_mtc example to a new test_prototype_mtc directory
 * Change to the test_prototype_mtc directory
 * Type ``activitysim run -c configs -o output -d data`` to run the example
 * Review the outputs in the output directory

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -24,7 +24,7 @@ installs a variety of things on your system, and it is quite likely to be flagge
 Windows, anti-virus, or institutional IT policies as "unusual" software, which
 may require special treatment to actually install and use.
 
-Download the installer from GitHub `here <https://github.com/ActivitySim/activitysim/releases/download/v1.2.0/Activitysim-1.2.0-Windows-x86_64.exe`__.
+Download the installer from GitHub `here <https://github.com/ActivitySim/activitysim/releases/download/v1.2.0/Activitysim-1.2.0-Windows-x86_64.exe>`__.
 It is strongly recommended to choose the option to install "for me only", as this
 should not require administrator privileges on your machine.  Pay attention
 to the *complete path* of the installation location. You will need to know


### PR DESCRIPTION
As noted in #641, black is the new black, and our code is so 2022.  This PR is a quick patch to keep us running, and prevents the environments from upgrading to the new black.  A more complete style update will come soon, to get the entire codebase to play nicely not only with black 2023 but also flake8.