### PR TITLE
Selecting choices from joint tour participant ID column explicitly;

### DIFF
--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -369,7 +369,7 @@ def joint_tour_participation(tours, persons_merged, chunk_size, trace_hh_id):
         # its value depends on whether the candidate's 'participant_id' is in the joint_tour_participant index
         survey_participants_df = estimator.get_survey_table("joint_tour_participants")
         participate = pd.Series(
-            choices.index.isin(survey_participants_df.index.values), index=choices.index
+            choices.index.isin(survey_participants_df.participant_id), index=choices.index
         )
 
         # but estimation software wants to know the choices value (alternative index)


### PR DESCRIPTION
In estimation mode, the index of survey_participants_df does not reflect participant_id (as tested by using PSRC survey data).  This change uses the ID column directly to select the choice set instead of assuming an index has been properly set. 

This was tested and works in both estimation and simulation mode. Perhaps it's preferable to ensure the index is set upstream, but this was the clearest route for me to continue producing estimation data bundles. 