### PR TITLE
BayDAG Contribution #2: Enhanced Disaggregate Accessibility Merging

### DIFF
--- a/activitysim/abm/models/disaggregate_accessibility.py
+++ b/activitysim/abm/models/disaggregate_accessibility.py
@@ -154,6 +154,15 @@ class DisaggregateAccessibilitySettings(PydanticReadable, extra="forbid"):
       procedure work.
     """
 
+    KEEP_COLS: list[str] | None
+    """
+    Disaggreate accessibility table is grouped by the "by" cols above and the KEEP_COLS are averaged
+    across the group.  Initializing the below as NA if not in the auto ownership level, they are skipped
+    in the groupby mean and the values are correct. 
+    (It's a way to avoid having to update code to reshape the table and introduce new functionality there.)
+    If none, will keep all of the columns with "accessibility" in the name.
+    """
+
     FROM_TEMPLATES: bool = False
     annotate_proto_tables: list[DisaggregateAccessibilityAnnotateSettings] = []
     """

--- a/activitysim/abm/models/disaggregate_accessibility.py
+++ b/activitysim/abm/models/disaggregate_accessibility.py
@@ -154,7 +154,7 @@ class DisaggregateAccessibilitySettings(PydanticReadable, extra="forbid"):
       procedure work.
     """
 
-    KEEP_COLS: list[str] | None
+    KEEP_COLS: list[str] | None = None
     """
     Disaggreate accessibility table is grouped by the "by" cols above and the KEEP_COLS are averaged
     across the group.  Initializing the below as NA if not in the auto ownership level, they are skipped
@@ -931,6 +931,7 @@ def compute_disaggregate_accessibility(
         assert df is not None
         assert annotations is not None
         assign_columns(
+            state,
             df=df,
             model_settings={
                 **annotations.annotate.dict(),

--- a/activitysim/abm/tables/disaggregate_accessibility.py
+++ b/activitysim/abm/tables/disaggregate_accessibility.py
@@ -172,14 +172,13 @@ def disaggregate_accessibility(state: workflow.State):
     accessibility_cols = [
         x for x in proto_accessibility_df.columns if "accessibility" in x
     ]
+    keep_cols = model_settings.get("KEEP_COLS", accessibility_cols)
 
     # Parse the merging parameters
     assert merging_params is not None
 
     # Check if already assigned!
-    if set(accessibility_cols).intersection(persons_merged_df.columns) == set(
-        accessibility_cols
-    ):
+    if set(keep_cols).intersection(persons_merged_df.columns) == set(keep_cols):
         return
 
     # Find the nearest zone (spatially) with accessibilities calculated
@@ -211,7 +210,7 @@ def disaggregate_accessibility(state: workflow.State):
     # because it will get slightly different logsums for households in the same zone.
     # This is because different destination zones were selected. To resolve, get mean by cols.
     right_df = (
-        proto_accessibility_df.groupby(merge_cols)[accessibility_cols]
+        proto_accessibility_df.groupby(merge_cols)[keep_cols]
         .mean()
         .sort_values(nearest_cols)
         .reset_index()
@@ -244,9 +243,9 @@ def disaggregate_accessibility(state: workflow.State):
         )
 
         # Predict the nearest person ID and pull the logsums
-        matched_logsums_df = right_df.loc[clf.predict(x_pop)][
-            accessibility_cols
-        ].reset_index(drop=True)
+        matched_logsums_df = right_df.loc[clf.predict(x_pop)][keep_cols].reset_index(
+            drop=True
+        )
         merge_df = pd.concat(
             [left_df.reset_index(drop=False), matched_logsums_df], axis=1
         ).set_index("person_id")
@@ -278,9 +277,9 @@ def disaggregate_accessibility(state: workflow.State):
 
     # Check that it was correctly left-joined
     assert all(persons_merged_df[merge_cols] == merge_df[merge_cols])
-    assert any(merge_df[accessibility_cols].isnull())
+    assert any(merge_df[keep_cols].isnull())
 
     # Inject merged accessibilities so that it can be included in persons_merged function
-    state.add_table("disaggregate_accessibility", merge_df[accessibility_cols])
+    state.add_table("disaggregate_accessibility", merge_df[keep_cols])
 
-    return merge_df[accessibility_cols]
+    return merge_df[keep_cols]

--- a/activitysim/abm/tables/disaggregate_accessibility.py
+++ b/activitysim/abm/tables/disaggregate_accessibility.py
@@ -172,7 +172,9 @@ def disaggregate_accessibility(state: workflow.State):
     accessibility_cols = [
         x for x in proto_accessibility_df.columns if "accessibility" in x
     ]
-    keep_cols = model_settings.get("KEEP_COLS", accessibility_cols)
+    keep_cols = model_settings.KEEP_COLS
+    if keep_cols is None:
+        keep_cols = accessibility_cols
 
     # Parse the merging parameters
     assert merging_params is not None

--- a/activitysim/abm/tables/disaggregate_accessibility.py
+++ b/activitysim/abm/tables/disaggregate_accessibility.py
@@ -107,7 +107,7 @@ def maz_centroids(state: workflow.State):
 
 
 @workflow.table
-def proto_disaggregate_accessibility(state: workflow.State):
+def proto_disaggregate_accessibility(state: workflow.State) -> pd.DataFrame:
     # Read existing accessibilities, but is not required to enable model compatibility
     df = input.read_input_table(
         state, "proto_disaggregate_accessibility", required=False
@@ -130,7 +130,7 @@ def proto_disaggregate_accessibility(state: workflow.State):
 
 
 @workflow.table
-def disaggregate_accessibility(state: workflow.State):
+def disaggregate_accessibility(state: workflow.State) -> pd.DataFrame:
     """
     This step initializes pre-computed disaggregate accessibility and merges it onto the full synthetic population.
     Function adds merged all disaggregate accessibility tables to the pipeline but returns nothing.
@@ -169,12 +169,11 @@ def disaggregate_accessibility(state: workflow.State):
     )
     merging_params = model_settings.MERGE_ON
     nearest_method = model_settings.NEAREST_METHOD
-    accessibility_cols = [
-        x for x in proto_accessibility_df.columns if "accessibility" in x
-    ]
-    keep_cols = model_settings.KEEP_COLS
-    if keep_cols is None:
-        keep_cols = accessibility_cols
+
+    if model_settings.KEEP_COLS is None:
+        keep_cols = [x for x in proto_accessibility_df.columns if "accessibility" in x]
+    else:
+        keep_cols = model_settings.KEEP_COLS
 
     # Parse the merging parameters
     assert merging_params is not None


### PR DESCRIPTION
This pull request gives the user greater flexibility to join disaggregate accessibilities to the households / person tables. The original design for the model just joined the disaggregate accessibilities to the household table by a set of auto ownership and home zone.  This was insufficient for the purpose of joining all auto ownership levels created in the disaggregate accessibilities model so they could be applied to the alternatives in the auto ownership model.  

See the SANDAG ABM3 configs for an example implementation: [yaml](https://github.com/SANDAG/ABM/blob/ABM3_develop/src/asim/configs/resident/disaggregate_accessibility.yaml#L120) and [annotator](https://github.com/SANDAG/ABM/blob/ABM3_develop/src/asim/configs/resident/annotate_disaggregate_accessibility.csv).

Required for SANDAG ABM3 production? -- yes