### PR TITLE
BayDAG Contribution #4: Joint Tour Destination Performance

### DIFF
--- a/activitysim/abm/models/joint_tour_destination.py
+++ b/activitysim/abm/models/joint_tour_destination.py
@@ -67,7 +67,7 @@ def joint_tour_destination(
 
     choices_df, save_sample_df = tour_destination.run_tour_destination(
         state,
-        tours,
+        joint_tours,
         persons_merged,
         want_logsums,
         want_sample_table,


### PR DESCRIPTION
The joint tour destination model ran for all tours instead of just joint tours.  This pull request fixes that bug and will reduce the computation resources required for this model.

Required for SANDAG ABM3 production? -- No