### PR TITLE
BayDAG Contribution #5: Joint Tour Frequency and Composition Estimation

### DIFF
--- a/activitysim/abm/models/joint_tour_frequency_composition.py
+++ b/activitysim/abm/models/joint_tour_frequency_composition.py
@@ -55,9 +55,11 @@ def joint_tour_frequency_composition(
             model_settings_file_name,
         )
 
+    # FIXME setting index as "alt" causes crash in estimation mode...
     alts = simulate.read_model_alts(
-        state, "joint_tour_frequency_composition_alternatives.csv", set_index="alt"
+        state, "joint_tour_frequency_composition_alternatives.csv", set_index=None
     )
+    alts.index = alts["alt"].values
 
     # - only interested in households with more than one cdap travel_active person and
     # - at least one non-preschooler
@@ -116,13 +118,15 @@ def joint_tour_frequency_composition(
         estimator.write_model_settings(model_settings, model_settings_file_name)
         estimator.write_coefficients(coefficients_df, model_settings)
         estimator.write_choosers(choosers)
-        estimator.write_alternatives(alts)
 
         assert choosers.index.name == "household_id"
         assert "household_id" not in choosers.columns
         choosers["household_id"] = choosers.index
 
         estimator.set_chooser_id(choosers.index.name)
+
+        # FIXME set_alt_id - do we need this for interaction_simulate estimation bundle tables?
+        estimator.set_alt_id("alt_id")
 
     # The choice value 'joint_tour_frequency_composition' assigned by interaction_simulate
     # is the index value of the chosen alternative in the alternatives table.
@@ -157,6 +161,7 @@ def joint_tour_frequency_composition(
     # - but we don't know the tour participants yet
     # - so we arbitrarily choose the first person in the household
     # - to be point person for the purpose of generating an index and setting origin
+    # FIXME: not all models are guaranteed to have PNUM
     temp_point_persons = persons.loc[persons.PNUM == 1]
     temp_point_persons["person_id"] = temp_point_persons.index
     temp_point_persons = temp_point_persons.set_index("household_id")


### PR DESCRIPTION
ActivitySim is very particular about what the index is named for the alternatives file when trying to create estimation data bundles.  (It comes back to this code [here](https://github.com/ActivitySim/activitysim/blob/main/activitysim/abm/models/util/estimation.py#L346)). This fix is required in order for this model to run successfully in estimation mode. The joint tour frequency and composition model was included as part of the [original BayDAG contribution](https://github.com/ActivitySim/activitysim/pull/657).

Required for SANDAG ABM3 production? -- No