### PR TITLE
BayDAG Contribution #6: Joint Tour Participation Infinite Loop

### DIFF
--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -214,6 +214,10 @@ def participants_chooser(
                 probs[choice_col] = np.where(probs[choice_col] > 0, 1, 0)
                 non_choice_col = [col for col in probs.columns if col != choice_col][0]
                 probs[non_choice_col] = 1 - probs[choice_col]
+                if iter > MAX_ITERATIONS + 1:
+                    raise RuntimeError(
+                        f"{num_tours_remaining} tours could not be satisfied even with forcing participation"
+                    )
             else:
                 raise RuntimeError(
                     f"{num_tours_remaining} tours could not be satisfied after {iter} iterations"


### PR DESCRIPTION
The joint tour participation model will iterate when selecting participants until the composition is met. After a set number of iterations, the model will force anyone with a non-zero probability to be in the joint tour which can help for cases where the probabilities are very small for members that need to be on the joint tour to satisfy the composition requirements.  However, there can be a case where all household members with non-zero probability are forced to be on the joint tour and the tour is still not satisfied.  If this happens, the current model will keep iterating in the infinite loop.  This PR adds code to error out if this scenario arises so that the user can either fix their input data or their specifications (I have only seen this happen due to inconsistent reporting in survey data when running in estimation mode).

Required for SANDAG ABM3 production? -- No