### PR TITLE
BayDAG Contribution #7: Sampling in EDB for Location Choice

### DIFF
--- a/activitysim/abm/models/location_choice.py
+++ b/activitysim/abm/models/location_choice.py
@@ -501,7 +501,6 @@ def run_location_sample(
             survey_choices["person_id"].isin(choices.index)
             & (survey_choices.alt_dest > 0)
         ]
-
         # merging survey destination into table if not available
         joined_data = survey_choices.merge(
             choices, on=["person_id", "alt_dest"], how="left", indicator=True

--- a/activitysim/abm/models/location_choice.py
+++ b/activitysim/abm/models/location_choice.py
@@ -152,7 +152,7 @@ def _location_sample(
         logger.info(
             f"SAMPLE_SIZE set to 0 for {trace_label} because disable_destination_sampling is set"
         )
-    
+
     locals_d = {
         "skims": skims,
         "segment_size": segment_name,

--- a/activitysim/core/configuration/logit.py
+++ b/activitysim/core/configuration/logit.py
@@ -203,7 +203,6 @@ class TourLocationComponentSettings(LocationComponentSettings, extra="forbid"):
     Larch does not yet support sampling alternatives for estimation, 
     but this setting is still helpful for estimation mode runtime.
     """
-    
 
 
 class TourModeComponentSettings(TemplatedLogitComponentSettings, extra="forbid"):

--- a/activitysim/core/configuration/logit.py
+++ b/activitysim/core/configuration/logit.py
@@ -195,6 +195,16 @@ class TourLocationComponentSettings(LocationComponentSettings, extra="forbid"):
     ORIG_ZONE_ID: str | None = None
     """This setting appears to do nothing..."""
 
+    ESTIMATION_SAMPLE_SIZE: int = 0
+    """
+    The number of alternatives to sample for estimation mode.
+    If zero, then all alternatives are used.
+    Truth alternative will be included in the sample.
+    Larch does not yet support sampling alternatives for estimation, 
+    but this setting is still helpful for estimation mode runtime.
+    """
+    
+
 
 class TourModeComponentSettings(TemplatedLogitComponentSettings, extra="forbid"):
     MODE_CHOICE_LOGSUM_COLUMN_NAME: str | None = None


### PR DESCRIPTION
Currently, estimation mode will include every single alternative for the location choice models.  This can be very onerous for 2-zone systems (SANDAG's workplace location choice estimation ran took multiple hours to run).  The code contributed here allows for the user to specify a sample rate to be used in estimation mode.  There is an additional logic to ensure that the actual observed alternative is included in the sampled alternatives so that downstream models will be using the correct destination. Using this "shortcut" for SANDAG decreased the runtime for this model to ~10 mins instead of hours.

Note that sampling is not yet supported in the actual model estimation process in larch yet. (Something [proposed for future enhancements](https://github.com/ActivitySim/activitysim/issues/731).)  This code just allows the user to run estimation mode much faster so downstream model EDBs can be created in less time.

Required for SANDAG ABM3 production? -- No