### PR TITLE
BayDAG Contribution #8: Landuse and Reindex available in location choice

### DIFF
--- a/activitysim/abm/models/location_choice.py
+++ b/activitysim/abm/models/location_choice.py
@@ -17,6 +17,7 @@ from activitysim.core.configuration.logit import (
 )
 from activitysim.core.interaction_sample import interaction_sample
 from activitysim.core.interaction_sample_simulate import interaction_sample_simulate
+from activitysim.core.util import reindex
 
 # import multiprocessing
 
@@ -157,6 +158,8 @@ def _location_sample(
         "orig_col_name": skims.orig_key,  # added for sharrow flows
         "dest_col_name": skims.dest_key,  # added for sharrow flows
         "timeframe": "timeless",
+        "reindex": reindex,
+        "land_use": inject.get_table("land_use").to_frame(),
     }
     locals_d.update(model_settings.CONSTANTS or {})
 
@@ -620,6 +623,8 @@ def run_location_simulate(
         "orig_col_name": skims.orig_key,  # added for sharrow flows
         "dest_col_name": skims.dest_key,  # added for sharrow flows
         "timeframe": "timeless",
+        "reindex": reindex,
+        "land_use": inject.get_table("land_use").to_frame(),
     }
     locals_d.update(model_settings.CONSTANTS or {})
 

--- a/activitysim/abm/models/location_choice.py
+++ b/activitysim/abm/models/location_choice.py
@@ -159,7 +159,7 @@ def _location_sample(
         "dest_col_name": skims.dest_key,  # added for sharrow flows
         "timeframe": "timeless",
         "reindex": reindex,
-        "land_use": inject.get_table("land_use").to_frame(),
+        "land_use": state.get_dataframe("land_use"),
     }
     locals_d.update(model_settings.CONSTANTS or {})
 
@@ -624,7 +624,7 @@ def run_location_simulate(
         "dest_col_name": skims.dest_key,  # added for sharrow flows
         "timeframe": "timeless",
         "reindex": reindex,
-        "land_use": inject.get_table("land_use").to_frame(),
+        "land_use": state.get_dataframe("land_use"),
     }
     locals_d.update(model_settings.CONSTANTS or {})
 

--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -193,7 +193,7 @@ def _destination_sample(
             "size_terms": size_term_matrix,
             "size_terms_array": size_term_matrix.df.to_numpy(),
             "timeframe": "trip",
-            "land_use": inject.get_table("land_use").to_frame(),
+            "land_use": state.get_dataframe("land_use"),
         }
     )
     locals_dict.update(skims)
@@ -926,7 +926,7 @@ def trip_destination_simulate(
             "size_terms": size_term_matrix,
             "size_terms_array": size_term_matrix.df.to_numpy(),
             "timeframe": "trip",
-            "land_use": inject.get_table("land_use").to_frame(),
+            "land_use": state.get_dataframe("land_use"),
         }
     )
     locals_dict.update(skims)

--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -193,6 +193,7 @@ def _destination_sample(
             "size_terms": size_term_matrix,
             "size_terms_array": size_term_matrix.df.to_numpy(),
             "timeframe": "trip",
+            "land_use": inject.get_table("land_use").to_frame(),
         }
     )
     locals_dict.update(skims)
@@ -925,6 +926,7 @@ def trip_destination_simulate(
             "size_terms": size_term_matrix,
             "size_terms_array": size_term_matrix.df.to_numpy(),
             "timeframe": "trip",
+            "land_use": inject.get_table("land_use").to_frame(),
         }
     )
     locals_dict.update(skims)


### PR DESCRIPTION
This pull request adds the ability to call the landuse table and the "reindex" function in the location choice model. This is required for the SANDAG ABM3 model calibration.  Getting county-to-county (or whatever geographic level) flows is important for calibration of workplace location models. The easiest way to accomplish this is to look at the origin home county and the destination county of the alternative and add/subtract utility for the correct combination.  The county of the alternative is provided by "reindexing" the county of that zone from the landuse table.

Previous models have gotten around this limitation by creating a separate skim that contains the county.  The skim is then called in the model.  This requires additional overhead in terms of creating, loading, and maintaining that skim, is not efficient from a memory perspective, and is opaque to the users.  This PR aims to provide a better way.

Required for SANDAG ABM3 production? -- yes