### PR TITLE
update repo test pointers

### DIFF
--- a/activitysim/examples/external_example_manifest.yaml
+++ b/activitysim/examples/external_example_manifest.yaml
@@ -13,11 +13,11 @@
 #
 
 prototype_mtc:
-  url: https://github.com/jpn--/activitysim-prototype-mtc/archive/refs/tags/v1.3.1.tar.gz
+  url: https://github.com/ActivitySim/activitysim-prototype-mtc/archive/refs/tags/v1.3.1.tar.gz
   sha256: ec53c6e72da1444bd5808de8c644cea75db284dfcc419b776575ba532b3ccb87
   assets:
     test/prototype_mtc_reference_pipeline.zip:
-      url: https://github.com/jpn--/activitysim-prototype-mtc/releases/download/v1.3.1/prototype_mtc_reference_pipeline.zip
+      url: https://github.com/ActivitySim/activitysim-prototype-mtc/releases/download/v1.3.1/prototype_mtc_reference_pipeline.zip
       sha256: 394e5b403d4c61d5214493cefe161432db840ba4967c23c999d914178d43a1f0
 
 estimation_example:


### PR DESCRIPTION
Change the progressive test repo from `jpn--` to `ActivitySim`; it was accidentally never moved when the progressive tests were originally committed.