### PR TITLE
`cleanup_failed_trips` requires workflow state

### DIFF
--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -1598,7 +1598,7 @@ def trip_destination(
                     trips_df.index[trips_df.failed], level="trip_id", inplace=True
                 )
 
-            trips_df = cleanup_failed_trips(trips_df)
+            trips_df = cleanup_failed_trips(state, trips_df)
 
         trips_df.drop(columns="failed", inplace=True, errors="ignore")
 

--- a/activitysim/abm/models/trip_purpose_and_destination.py
+++ b/activitysim/abm/models/trip_purpose_and_destination.py
@@ -238,7 +238,7 @@ def trip_purpose_and_destination(
         state.settings.downcast_float,
     )
 
-    trips_df = cleanup_failed_trips(trips_df)
+    trips_df = cleanup_failed_trips(state, trips_df)
 
     state.add_table("trips", trips_df)
 

--- a/activitysim/abm/models/trip_scheduling.py
+++ b/activitysim/abm/models/trip_scheduling.py
@@ -660,7 +660,7 @@ def trip_scheduling(
             )
 
         trips_df["failed"] = choices.isnull()
-        trips_df = cleanup_failed_trips(trips_df)
+        trips_df = cleanup_failed_trips(state, trips_df)
         choices = choices.reindex(trips_df.index)
 
     trips_df["depart"] = choices

--- a/activitysim/abm/models/util/trip.py
+++ b/activitysim/abm/models/util/trip.py
@@ -52,7 +52,7 @@ def flag_failed_trip_leg_mates(trips_df, col_name):
     #     trips_df.loc[failed_trip_leg_mates, col_name] = True
 
 
-def cleanup_failed_trips(trips):
+def cleanup_failed_trips(state: workflow.State, trips: pd.DataFrame):
     """
     drop failed trips and cleanup fields in leg_mates:
 


### PR DESCRIPTION
The `cleanup_failed_trips` function requires the `state` to handle dtype down casting correctly.  Otherwise, the model will crash when failed trips happen. With large sample sizes, this occurs on a few trips.