### PR TITLE
Common settings for fastmath, sharrow_skip, and other compute controls across components

### DIFF
--- a/activitysim/abm/models/atwork_subtour_frequency.py
+++ b/activitysim/abm/models/atwork_subtour_frequency.py
@@ -117,7 +117,7 @@ def atwork_subtour_frequency(
         trace_label=trace_label,
         trace_choice_name="atwork_subtour_frequency",
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/atwork_subtour_frequency.py
+++ b/activitysim/abm/models/atwork_subtour_frequency.py
@@ -117,6 +117,7 @@ def atwork_subtour_frequency(
         trace_label=trace_label,
         trace_choice_name="atwork_subtour_frequency",
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/atwork_subtour_frequency.py
+++ b/activitysim/abm/models/atwork_subtour_frequency.py
@@ -117,7 +117,7 @@ def atwork_subtour_frequency(
         trace_label=trace_label,
         trace_choice_name="atwork_subtour_frequency",
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/atwork_subtour_scheduling.py
+++ b/activitysim/abm/models/atwork_subtour_scheduling.py
@@ -56,7 +56,6 @@ def atwork_subtour_scheduling(
     estimator = estimation.manager.begin_estimation(state, "atwork_subtour_scheduling")
 
     model_spec = state.filesystem.read_model_spec(file_name=model_settings.SPEC)
-    sharrow_skip = model_settings.sharrow_skip
     coefficients_df = state.filesystem.read_model_coefficients(model_settings)
     model_spec = simulate.eval_coefficients(
         state, model_spec, coefficients_df, estimator
@@ -96,7 +95,7 @@ def atwork_subtour_scheduling(
         estimator=estimator,
         chunk_size=state.settings.chunk_size,
         trace_label=trace_label,
-        sharrow_skip=sharrow_skip,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/atwork_subtour_scheduling.py
+++ b/activitysim/abm/models/atwork_subtour_scheduling.py
@@ -95,7 +95,7 @@ def atwork_subtour_scheduling(
         estimator=estimator,
         chunk_size=state.settings.chunk_size,
         trace_label=trace_label,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/auto_ownership.py
+++ b/activitysim/abm/models/auto_ownership.py
@@ -23,7 +23,7 @@ from .util import annotate
 logger = logging.getLogger(__name__)
 
 
-class AutoOwnershipSettings(LogitComponentSettings):
+class AutoOwnershipSettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for the `auto_ownership` component.
     """

--- a/activitysim/abm/models/auto_ownership.py
+++ b/activitysim/abm/models/auto_ownership.py
@@ -100,7 +100,7 @@ def auto_ownership_simulate(
         trace_choice_name="auto_ownership",
         log_alt_losers=log_alt_losers,
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/auto_ownership.py
+++ b/activitysim/abm/models/auto_ownership.py
@@ -9,14 +9,15 @@ from pydantic import validator
 
 from activitysim.core import (
     config,
-    expressions,
     estimation,
+    expressions,
     simulate,
     tracing,
     workflow,
 )
 from activitysim.core.configuration.base import PreprocessorSettings, PydanticReadable
 from activitysim.core.configuration.logit import LogitComponentSettings
+
 from .util import annotate
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ def auto_ownership_simulate(
         trace_choice_name="auto_ownership",
         log_alt_losers=log_alt_losers,
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     if estimator:

--- a/activitysim/abm/models/auto_ownership.py
+++ b/activitysim/abm/models/auto_ownership.py
@@ -100,7 +100,7 @@ def auto_ownership_simulate(
         trace_choice_name="auto_ownership",
         log_alt_losers=log_alt_losers,
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/cdap.py
+++ b/activitysim/abm/models/cdap.py
@@ -18,9 +18,9 @@ from activitysim.core import (
     workflow,
 )
 from activitysim.core.configuration.base import (
+    ComputeSettings,
     PreprocessorSettings,
     PydanticReadable,
-    SharrowSettings,
 )
 from activitysim.core.util import reindex
 
@@ -38,7 +38,7 @@ class CdapSettings(PydanticReadable, extra="forbid"):
     annotate_households: PreprocessorSettings | None = None
     COEFFICIENTS: Path
     CONSTANTS: dict[str, Any] = {}
-    sharrow_settings: SharrowSettings | None = None
+    compute_settings: ComputeSettings | None = None
 
 
 @workflow.step
@@ -207,7 +207,7 @@ def cdap_simulate(
             trace_hh_id=trace_hh_id,
             trace_label=trace_label,
             add_joint_tour_utility=add_joint_tour_utility,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
     else:
         choices = cdap.run_cdap(
@@ -221,7 +221,7 @@ def cdap_simulate(
             chunk_size=state.settings.chunk_size,
             trace_hh_id=trace_hh_id,
             trace_label=trace_label,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
 
     if estimator:

--- a/activitysim/abm/models/cdap.py
+++ b/activitysim/abm/models/cdap.py
@@ -17,7 +17,11 @@ from activitysim.core import (
     tracing,
     workflow,
 )
-from activitysim.core.configuration.base import PreprocessorSettings, PydanticReadable
+from activitysim.core.configuration.base import (
+    PreprocessorSettings,
+    PydanticReadable,
+    SharrowSettings,
+)
 from activitysim.core.util import reindex
 
 logger = logging.getLogger(__name__)
@@ -34,6 +38,7 @@ class CdapSettings(PydanticReadable, extra="forbid"):
     annotate_households: PreprocessorSettings | None = None
     COEFFICIENTS: Path
     CONSTANTS: dict[str, Any] = {}
+    sharrow_settings: SharrowSettings | None = None
 
 
 @workflow.step
@@ -202,6 +207,7 @@ def cdap_simulate(
             trace_hh_id=trace_hh_id,
             trace_label=trace_label,
             add_joint_tour_utility=add_joint_tour_utility,
+            sharrow_settings=model_settings.sharrow_settings,
         )
     else:
         choices = cdap.run_cdap(
@@ -215,6 +221,7 @@ def cdap_simulate(
             chunk_size=state.settings.chunk_size,
             trace_hh_id=trace_hh_id,
             trace_label=trace_label,
+            sharrow_settings=model_settings.sharrow_settings,
         )
 
     if estimator:

--- a/activitysim/abm/models/free_parking.py
+++ b/activitysim/abm/models/free_parking.py
@@ -118,6 +118,7 @@ def free_parking(
         trace_label=trace_label,
         trace_choice_name="free_parking_at_work",
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     free_parking_alt = model_settings.FREE_PARKING_ALT

--- a/activitysim/abm/models/free_parking.py
+++ b/activitysim/abm/models/free_parking.py
@@ -118,7 +118,7 @@ def free_parking(
         trace_label=trace_label,
         trace_choice_name="free_parking_at_work",
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     free_parking_alt = model_settings.FREE_PARKING_ALT

--- a/activitysim/abm/models/free_parking.py
+++ b/activitysim/abm/models/free_parking.py
@@ -118,7 +118,7 @@ def free_parking(
         trace_label=trace_label,
         trace_choice_name="free_parking_at_work",
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     free_parking_alt = model_settings.FREE_PARKING_ALT

--- a/activitysim/abm/models/joint_tour_composition.py
+++ b/activitysim/abm/models/joint_tour_composition.py
@@ -123,6 +123,7 @@ def joint_tour_composition(
         trace_label=trace_label,
         trace_choice_name="composition",
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/joint_tour_composition.py
+++ b/activitysim/abm/models/joint_tour_composition.py
@@ -123,7 +123,7 @@ def joint_tour_composition(
         trace_label=trace_label,
         trace_choice_name="composition",
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/joint_tour_composition.py
+++ b/activitysim/abm/models/joint_tour_composition.py
@@ -123,7 +123,7 @@ def joint_tour_composition(
         trace_label=trace_label,
         trace_choice_name="composition",
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/joint_tour_frequency.py
+++ b/activitysim/abm/models/joint_tour_frequency.py
@@ -112,6 +112,7 @@ def joint_tour_frequency(
         trace_label=trace_label,
         trace_choice_name="joint_tour_frequency",
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/joint_tour_frequency.py
+++ b/activitysim/abm/models/joint_tour_frequency.py
@@ -112,7 +112,7 @@ def joint_tour_frequency(
         trace_label=trace_label,
         trace_choice_name="joint_tour_frequency",
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/joint_tour_frequency.py
+++ b/activitysim/abm/models/joint_tour_frequency.py
@@ -112,7 +112,7 @@ def joint_tour_frequency(
         trace_label=trace_label,
         trace_choice_name="joint_tour_frequency",
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/joint_tour_frequency_composition.py
+++ b/activitysim/abm/models/joint_tour_frequency_composition.py
@@ -136,6 +136,7 @@ def joint_tour_frequency_composition(
         trace_choice_name=trace_label,
         estimator=estimator,
         explicit_chunk_size=0,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     if estimator:

--- a/activitysim/abm/models/joint_tour_frequency_composition.py
+++ b/activitysim/abm/models/joint_tour_frequency_composition.py
@@ -140,7 +140,7 @@ def joint_tour_frequency_composition(
         trace_choice_name=trace_label,
         estimator=estimator,
         explicit_chunk_size=0,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/joint_tour_frequency_composition.py
+++ b/activitysim/abm/models/joint_tour_frequency_composition.py
@@ -140,7 +140,7 @@ def joint_tour_frequency_composition(
         trace_choice_name=trace_label,
         estimator=estimator,
         explicit_chunk_size=0,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/joint_tour_frequency_composition.py
+++ b/activitysim/abm/models/joint_tour_frequency_composition.py
@@ -26,7 +26,7 @@ from activitysim.core.interaction_simulate import interaction_simulate
 logger = logging.getLogger(__name__)
 
 
-class JointTourFrequencyCompositionSettings(LogitComponentSettings):
+class JointTourFrequencyCompositionSettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for the `joint_tour_frequency_composition` component.
     """

--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -414,6 +414,7 @@ def joint_tour_participation(
         trace_choice_name="participation",
         custom_chooser=participants_chooser,
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     # choice is boolean (participate or not)

--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -418,7 +418,7 @@ def joint_tour_participation(
         trace_choice_name="participation",
         custom_chooser=participants_chooser,
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     # choice is boolean (participate or not)

--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -418,7 +418,7 @@ def joint_tour_participation(
         trace_choice_name="participation",
         custom_chooser=participants_chooser,
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     # choice is boolean (participate or not)

--- a/activitysim/abm/models/joint_tour_scheduling.py
+++ b/activitysim/abm/models/joint_tour_scheduling.py
@@ -104,7 +104,6 @@ def joint_tour_scheduling(
     estimator = estimation.manager.begin_estimation(state, "joint_tour_scheduling")
 
     model_spec = state.filesystem.read_model_spec(file_name=model_settings.SPEC)
-    sharrow_skip = model_settings.sharrow_skip
     coefficients_df = state.filesystem.read_model_coefficients(model_settings)
     model_spec = simulate.eval_coefficients(
         state, model_spec, coefficients_df, estimator
@@ -128,7 +127,7 @@ def joint_tour_scheduling(
         estimator=estimator,
         chunk_size=state.settings.chunk_size,
         trace_label=trace_label,
-        sharrow_skip=sharrow_skip,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/joint_tour_scheduling.py
+++ b/activitysim/abm/models/joint_tour_scheduling.py
@@ -127,7 +127,7 @@ def joint_tour_scheduling(
         estimator=estimator,
         chunk_size=state.settings.chunk_size,
         trace_label=trace_label,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/location_choice.py
+++ b/activitysim/abm/models/location_choice.py
@@ -192,6 +192,9 @@ def _location_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer=zone_layer,
+        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+            "sample"
+        ),
     )
 
     return choices

--- a/activitysim/abm/models/location_choice.py
+++ b/activitysim/abm/models/location_choice.py
@@ -192,7 +192,7 @@ def _location_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer=zone_layer,
-        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+        compute_settings=model_settings.compute_settings.subcomponent_settings(
             "sample"
         ),
     )
@@ -699,7 +699,7 @@ def run_location_simulate(
         trace_choice_name=model_settings.DEST_CHOICE_COLUMN_NAME,
         estimator=estimator,
         skip_choice=skip_choice,
-        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+        compute_settings=model_settings.compute_settings.subcomponent_settings(
             "simulate"
         ),
     )

--- a/activitysim/abm/models/location_choice.py
+++ b/activitysim/abm/models/location_choice.py
@@ -699,6 +699,9 @@ def run_location_simulate(
         trace_choice_name=model_settings.DEST_CHOICE_COLUMN_NAME,
         estimator=estimator,
         skip_choice=skip_choice,
+        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+            "simulate"
+        ),
     )
 
     if not want_logsums:

--- a/activitysim/abm/models/mandatory_tour_frequency.py
+++ b/activitysim/abm/models/mandatory_tour_frequency.py
@@ -134,7 +134,7 @@ def mandatory_tour_frequency(
         trace_label=trace_label,
         trace_choice_name="mandatory_tour_frequency",
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/mandatory_tour_frequency.py
+++ b/activitysim/abm/models/mandatory_tour_frequency.py
@@ -134,6 +134,7 @@ def mandatory_tour_frequency(
         trace_label=trace_label,
         trace_choice_name="mandatory_tour_frequency",
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/mandatory_tour_frequency.py
+++ b/activitysim/abm/models/mandatory_tour_frequency.py
@@ -53,7 +53,7 @@ def add_null_results(state, trace_label, mandatory_tour_frequency_settings):
     state.add_table("persons", persons)
 
 
-class MandatoryTourFrequencySettings(LogitComponentSettings):
+class MandatoryTourFrequencySettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for the `mandatory_tour_frequency` component.
     """

--- a/activitysim/abm/models/mandatory_tour_frequency.py
+++ b/activitysim/abm/models/mandatory_tour_frequency.py
@@ -134,7 +134,7 @@ def mandatory_tour_frequency(
         trace_label=trace_label,
         trace_choice_name="mandatory_tour_frequency",
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     # convert indexes to alternative names

--- a/activitysim/abm/models/non_mandatory_tour_frequency.py
+++ b/activitysim/abm/models/non_mandatory_tour_frequency.py
@@ -312,6 +312,7 @@ def non_mandatory_tour_frequency(
             trace_choice_name="non_mandatory_tour_frequency",
             estimator=estimator,
             explicit_chunk_size=model_settings.explicit_chunk,
+            fastmath=model_settings.sharrow_fastmath,
         )
 
         if estimator:

--- a/activitysim/abm/models/non_mandatory_tour_frequency.py
+++ b/activitysim/abm/models/non_mandatory_tour_frequency.py
@@ -312,7 +312,7 @@ def non_mandatory_tour_frequency(
             trace_choice_name="non_mandatory_tour_frequency",
             estimator=estimator,
             explicit_chunk_size=model_settings.explicit_chunk,
-            fastmath=model_settings.sharrow_fastmath,
+            sharrow_settings=model_settings.sharrow_settings,
         )
 
         if estimator:

--- a/activitysim/abm/models/non_mandatory_tour_frequency.py
+++ b/activitysim/abm/models/non_mandatory_tour_frequency.py
@@ -12,8 +12,8 @@ import pandas as pd
 
 from activitysim.abm.models.util import annotate
 from activitysim.abm.models.util.overlap import (
-    person_max_window,
     person_available_periods,
+    person_max_window,
 )
 from activitysim.abm.models.util.school_escort_tours_trips import (
     recompute_tour_count_statistics,
@@ -321,7 +321,7 @@ def non_mandatory_tour_frequency(
             trace_choice_name="non_mandatory_tour_frequency",
             estimator=estimator,
             explicit_chunk_size=model_settings.explicit_chunk,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
 
         if estimator:

--- a/activitysim/abm/models/non_mandatory_tour_frequency.py
+++ b/activitysim/abm/models/non_mandatory_tour_frequency.py
@@ -158,7 +158,7 @@ class NonMandatoryTourSpecSegment(PydanticReadable):
     COEFFICIENTS: Path
 
 
-class NonMandatoryTourFrequencySettings(LogitComponentSettings):
+class NonMandatoryTourFrequencySettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for the `non_mandatory_tour_frequency` component.
     """

--- a/activitysim/abm/models/school_escorting.py
+++ b/activitysim/abm/models/school_escorting.py
@@ -395,6 +395,22 @@ class SchoolEscortSettings(BaseLogitComponentSettings):
     ```
     """
 
+    sharrow_fastmath: bool = False
+    """Use fastmath when evaluating this component with sharrow.
+
+    The fastmath option can be used to speed up the evaluation of expressions in
+    this component's spec files, but it does so by making some simplifying
+    assumptions about the math, e.g. that neither inputs nor outputs of any
+    computations are NaN or Inf.  This can lead to errors when the assumptions
+    are violated.  If running in sharrow test mode generates errors, try turning
+    this setting off.
+
+    The default for most components is True, but due to the prevalence of NaN
+    values in the school escorting model, the default is False for this
+    component. It can be turned on if desired, but it is recommended to test
+    carefully that results are as expected.
+    """
+
     SIMULATE_CHOOSER_COLUMNS: list[str] | None = None
 
     SPEC: None = None

--- a/activitysim/abm/models/school_escorting.py
+++ b/activitysim/abm/models/school_escorting.py
@@ -500,9 +500,9 @@ def school_escorting(
             state, model_spec_raw, coefficients_df, estimator
         )
 
-        # allow for skipping sharrow entirely in this model with `sharrow_settings.skip: true`
+        # allow for skipping sharrow entirely in this model with `compute_settings.sharrow_skip: true`
         # or skipping stages selectively with a mapping of the stages to skip
-        stage_sharrow_settings = model_settings.sharrow_settings.subcomponent_settings(
+        stage_compute_settings = model_settings.compute_settings.subcomponent_settings(
             stage.upper()
         )
         # if stage_sharrow_skip:
@@ -572,7 +572,7 @@ def school_escorting(
             trace_choice_name="school_escorting_" + stage,
             estimator=estimator,
             explicit_chunk_size=model_settings.explicit_chunk,
-            sharrow_settings=stage_sharrow_settings,
+            compute_settings=stage_compute_settings,
         )
 
         if estimator:

--- a/activitysim/abm/models/school_escorting.py
+++ b/activitysim/abm/models/school_escorting.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -356,7 +356,7 @@ def create_school_escorting_bundles_table(choosers, tours, stage):
     return bundles
 
 
-class SchoolEscortSettings(BaseLogitComponentSettings):
+class SchoolEscortSettings(BaseLogitComponentSettings, extra="forbid"):
     """
     Settings for the `telecommute_frequency` component.
     """
@@ -401,6 +401,13 @@ class SchoolEscortSettings(BaseLogitComponentSettings):
 
     explicit_chunk: int = 0
     """If > 0, use this chunk size instead of adaptive chunking."""
+
+    LOGIT_TYPE: Literal["MNL"] = "MNL"
+    """Logit model mathematical form.
+
+    * "MNL"
+        Multinomial logit model.
+    """
 
 
 @workflow.step

--- a/activitysim/abm/models/school_escorting.py
+++ b/activitysim/abm/models/school_escorting.py
@@ -550,6 +550,7 @@ def school_escorting(
             trace_choice_name="school_escorting_" + stage,
             estimator=estimator,
             explicit_chunk_size=model_settings.explicit_chunk,
+            fastmath=model_settings.sharrow_fastmath,
         )
 
         if estimator:

--- a/activitysim/abm/models/stop_frequency.py
+++ b/activitysim/abm/models/stop_frequency.py
@@ -214,7 +214,7 @@ def stop_frequency(
             trace_label=tracing.extend_trace_label(trace_label, segment_name),
             trace_choice_name="stops",
             estimator=estimator,
-            fastmath=model_settings.sharrow_fastmath,
+            sharrow_settings=model_settings.sharrow_settings,
         )
 
         # convert indexes to alternative names

--- a/activitysim/abm/models/stop_frequency.py
+++ b/activitysim/abm/models/stop_frequency.py
@@ -214,6 +214,7 @@ def stop_frequency(
             trace_label=tracing.extend_trace_label(trace_label, segment_name),
             trace_choice_name="stops",
             estimator=estimator,
+            fastmath=model_settings.sharrow_fastmath,
         )
 
         # convert indexes to alternative names

--- a/activitysim/abm/models/stop_frequency.py
+++ b/activitysim/abm/models/stop_frequency.py
@@ -214,7 +214,7 @@ def stop_frequency(
             trace_label=tracing.extend_trace_label(trace_label, segment_name),
             trace_choice_name="stops",
             estimator=estimator,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
 
         # convert indexes to alternative names

--- a/activitysim/abm/models/telecommute_frequency.py
+++ b/activitysim/abm/models/telecommute_frequency.py
@@ -99,7 +99,7 @@ def telecommute_frequency(
         trace_label=trace_label,
         trace_choice_name="telecommute_frequency",
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     choices = pd.Series(model_spec.columns[choices.values], index=choices.index)

--- a/activitysim/abm/models/telecommute_frequency.py
+++ b/activitysim/abm/models/telecommute_frequency.py
@@ -99,6 +99,7 @@ def telecommute_frequency(
         trace_label=trace_label,
         trace_choice_name="telecommute_frequency",
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     choices = pd.Series(model_spec.columns[choices.values], index=choices.index)

--- a/activitysim/abm/models/telecommute_frequency.py
+++ b/activitysim/abm/models/telecommute_frequency.py
@@ -20,7 +20,7 @@ from activitysim.core.configuration.logit import LogitComponentSettings
 logger = logging.getLogger("activitysim")
 
 
-class TelecommuteFrequencySettings(LogitComponentSettings):
+class TelecommuteFrequencySettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for the `telecommute_frequency` component.
     """

--- a/activitysim/abm/models/telecommute_frequency.py
+++ b/activitysim/abm/models/telecommute_frequency.py
@@ -99,7 +99,7 @@ def telecommute_frequency(
         trace_label=trace_label,
         trace_choice_name="telecommute_frequency",
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     choices = pd.Series(model_spec.columns[choices.values], index=choices.index)

--- a/activitysim/abm/models/transit_pass_ownership.py
+++ b/activitysim/abm/models/transit_pass_ownership.py
@@ -93,7 +93,7 @@ def transit_pass_ownership(
         trace_label=trace_label,
         trace_choice_name="transit_pass_ownership",
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/transit_pass_ownership.py
+++ b/activitysim/abm/models/transit_pass_ownership.py
@@ -20,7 +20,7 @@ from activitysim.core.configuration.logit import LogitComponentSettings
 logger = logging.getLogger("activitysim")
 
 
-class TransitPassOwnershipSettings(LogitComponentSettings):
+class TransitPassOwnershipSettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for the `transit_pass_ownership` component.
     """

--- a/activitysim/abm/models/transit_pass_ownership.py
+++ b/activitysim/abm/models/transit_pass_ownership.py
@@ -93,7 +93,7 @@ def transit_pass_ownership(
         trace_label=trace_label,
         trace_choice_name="transit_pass_ownership",
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/transit_pass_ownership.py
+++ b/activitysim/abm/models/transit_pass_ownership.py
@@ -93,6 +93,7 @@ def transit_pass_ownership(
         trace_label=trace_label,
         trace_choice_name="transit_pass_ownership",
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     if estimator:

--- a/activitysim/abm/models/transit_pass_subsidy.py
+++ b/activitysim/abm/models/transit_pass_subsidy.py
@@ -92,6 +92,7 @@ def transit_pass_subsidy(
         trace_label=trace_label,
         trace_choice_name="transit_pass_subsidy",
         estimator=estimator,
+        compute_settings=model_settings.compute_settings,
     )
 
     if estimator:

--- a/activitysim/abm/models/trip_departure_choice.py
+++ b/activitysim/abm/models/trip_departure_choice.py
@@ -22,7 +22,7 @@ from activitysim.core import (
 from activitysim.core.configuration.base import (
     ComputeSettings,
     PreprocessorSettings,
-    PydanticSharrow,
+    PydanticCompute,
 )
 from activitysim.core.skim_dataset import SkimDataset
 from activitysim.core.skim_dictionary import SkimDict
@@ -501,7 +501,7 @@ def apply_stage_two_model(
     return trips["depart"].astype(int)
 
 
-class TripDepartureChoiceSettings(PydanticSharrow, extra="forbid"):
+class TripDepartureChoiceSettings(PydanticCompute, extra="forbid"):
     """
     Settings for the `trip_departure_choice` component.
     """

--- a/activitysim/abm/models/trip_departure_choice.py
+++ b/activitysim/abm/models/trip_departure_choice.py
@@ -20,9 +20,9 @@ from activitysim.core import (
     workflow,
 )
 from activitysim.core.configuration.base import (
+    ComputeSettings,
     PreprocessorSettings,
     PydanticSharrow,
-    SharrowSettings,
 )
 from activitysim.core.skim_dataset import SkimDataset
 from activitysim.core.skim_dictionary import SkimDict
@@ -191,7 +191,7 @@ def choose_tour_leg_pattern(
     trace_label="trace_label",
     *,
     chunk_sizer: chunk.ChunkSizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     alternatives = generate_alternatives(trip_segment, STOP_TIME_DURATION).sort_index()
     have_trace_targets = state.tracing.has_trace_targets(trip_segment)
@@ -245,7 +245,7 @@ def choose_tour_leg_pattern(
         trace_label,
         trace_rows,
         estimator=None,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
 
     interaction_utilities = pd.concat(
@@ -402,7 +402,7 @@ def apply_stage_two_model(
     trips,
     chunk_size,
     trace_label: str,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     if not trips.index.is_monotonic:
         trips = trips.sort_index()
@@ -473,7 +473,7 @@ def apply_stage_two_model(
                 spec,
                 trace_label=segment_trace_label,
                 chunk_sizer=chunk_sizer,
-                sharrow_settings=sharrow_settings,
+                compute_settings=compute_settings,
             )
 
             choices = pd.merge(
@@ -580,7 +580,7 @@ def trip_departure_choice(
         trips_merged_df,
         state.settings.chunk_size,
         trace_label,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     trips_df = trips

--- a/activitysim/abm/models/trip_departure_choice.py
+++ b/activitysim/abm/models/trip_departure_choice.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -20,7 +19,11 @@ from activitysim.core import (
     tracing,
     workflow,
 )
-from activitysim.core.configuration.base import PreprocessorSettings, PydanticReadable
+from activitysim.core.configuration.base import (
+    PreprocessorSettings,
+    PydanticSharrow,
+    SharrowSettings,
+)
 from activitysim.core.skim_dataset import SkimDataset
 from activitysim.core.skim_dictionary import SkimDict
 from activitysim.core.util import reindex
@@ -188,6 +191,7 @@ def choose_tour_leg_pattern(
     trace_label="trace_label",
     *,
     chunk_sizer: chunk.ChunkSizer,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     alternatives = generate_alternatives(trip_segment, STOP_TIME_DURATION).sort_index()
     have_trace_targets = state.tracing.has_trace_targets(trip_segment)
@@ -234,7 +238,14 @@ def choose_tour_leg_pattern(
         interaction_utilities,
         trace_eval_results,
     ) = interaction_simulate.eval_interaction_utilities(
-        state, spec, interaction_df, None, trace_label, trace_rows, estimator=None
+        state,
+        spec,
+        interaction_df,
+        None,
+        trace_label,
+        trace_rows,
+        estimator=None,
+        sharrow_settings=sharrow_settings,
     )
 
     interaction_utilities = pd.concat(
@@ -385,7 +396,14 @@ def choose_tour_leg_pattern(
     return choices
 
 
-def apply_stage_two_model(state, omnibus_spec, trips, chunk_size, trace_label):
+def apply_stage_two_model(
+    state: workflow.State,
+    omnibus_spec,
+    trips,
+    chunk_size,
+    trace_label: str,
+    sharrow_settings: SharrowSettings | None = None,
+):
     if not trips.index.is_monotonic:
         trips = trips.sort_index()
 
@@ -436,7 +454,7 @@ def apply_stage_two_model(state, omnibus_spec, trips, chunk_size, trace_label):
     trip_list = []
 
     for (
-        i,
+        _i,
         chooser_chunk,
         chunk_trace_label,
         chunk_sizer,
@@ -444,7 +462,7 @@ def apply_stage_two_model(state, omnibus_spec, trips, chunk_size, trace_label):
         for is_outbound, trip_segment in chooser_chunk.groupby(OUTBOUND):
             direction = OUTBOUND if is_outbound else "inbound"
             spec = get_spec_for_segment(omnibus_spec, direction)
-            segment_trace_label = "{}_{}".format(direction, chunk_trace_label)
+            segment_trace_label = f"{direction}_{chunk_trace_label}"
 
             patterns = build_patterns(trip_segment, time_windows)
 
@@ -455,6 +473,7 @@ def apply_stage_two_model(state, omnibus_spec, trips, chunk_size, trace_label):
                 spec,
                 trace_label=segment_trace_label,
                 chunk_sizer=chunk_sizer,
+                sharrow_settings=sharrow_settings,
             )
 
             choices = pd.merge(
@@ -482,7 +501,7 @@ def apply_stage_two_model(state, omnibus_spec, trips, chunk_size, trace_label):
     return trips["depart"].astype(int)
 
 
-class TripDepartureChoiceSettings(PydanticReadable, extra="forbid"):
+class TripDepartureChoiceSettings(PydanticSharrow, extra="forbid"):
     """
     Settings for the `trip_departure_choice` component.
     """
@@ -506,7 +525,6 @@ def trip_departure_choice(
     model_settings_file_name: str = "trip_departure_choice.yaml",
     trace_label: str = "trip_departure_choice",
 ) -> None:
-
     if model_settings is None:
         model_settings = TripDepartureChoiceSettings.read_settings_file(
             state.filesystem,
@@ -557,7 +575,12 @@ def trip_departure_choice(
         )
 
     choices = apply_stage_two_model(
-        state, spec, trips_merged_df, state.settings.chunk_size, trace_label
+        state,
+        spec,
+        trips_merged_df,
+        state.settings.chunk_size,
+        trace_label,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     trips_df = trips

--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -215,6 +215,9 @@ def _destination_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer=zone_layer,
+        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+            "sample"
+        ),
     )
 
     return choices

--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -215,7 +215,7 @@ def _destination_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer=zone_layer,
-        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+        compute_settings=model_settings.compute_settings.subcomponent_settings(
             "sample"
         ),
     )

--- a/activitysim/abm/models/trip_mode_choice.py
+++ b/activitysim/abm/models/trip_mode_choice.py
@@ -277,7 +277,7 @@ def trip_mode_choice(
             trace_label=segment_trace_label,
             trace_choice_name="trip_mode_choice",
             estimator=estimator,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
 
         if state.settings.trace_hh_id:

--- a/activitysim/abm/models/trip_mode_choice.py
+++ b/activitysim/abm/models/trip_mode_choice.py
@@ -277,7 +277,7 @@ def trip_mode_choice(
             trace_label=segment_trace_label,
             trace_choice_name="trip_mode_choice",
             estimator=estimator,
-            fastmath=model_settings.sharrow_fastmath,
+            sharrow_settings=model_settings.sharrow_settings,
         )
 
         if state.settings.trace_hh_id:

--- a/activitysim/abm/models/trip_mode_choice.py
+++ b/activitysim/abm/models/trip_mode_choice.py
@@ -277,6 +277,7 @@ def trip_mode_choice(
             trace_label=segment_trace_label,
             trace_choice_name="trip_mode_choice",
             estimator=estimator,
+            fastmath=model_settings.sharrow_fastmath,
         )
 
         if state.settings.trace_hh_id:

--- a/activitysim/abm/models/util/cdap.py
+++ b/activitysim/abm/models/util/cdap.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from activitysim.core import chunk, logit, simulate, tracing, workflow
-from activitysim.core.configuration.base import SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +185,7 @@ def individual_utilities(
     trace_label=None,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Calculate CDAP utilities for all individuals.
@@ -213,7 +213,7 @@ def individual_utilities(
         locals_d,
         trace_label=trace_label,
         chunk_sizer=chunk_sizer,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
 
     # add columns from persons to facilitate building household interactions
@@ -912,7 +912,7 @@ def household_activity_choices(
     add_joint_tour_utility=False,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Calculate household utilities for each activity pattern alternative for households of hhsize
@@ -966,7 +966,7 @@ def household_activity_choices(
             choosers,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
     if len(utils.index) == 0:
@@ -990,7 +990,7 @@ def household_activity_choices(
             choosers,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         # add joint util to util
@@ -1193,7 +1193,7 @@ def _run_cdap(
     add_joint_tour_utility,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ) -> pd.DataFrame | tuple:
     """
     Implements core run_cdap functionality on persons df (or chunked subset thereof)
@@ -1224,7 +1224,7 @@ def _run_cdap(
         trace_hh_id,
         trace_label,
         chunk_sizer=chunk_sizer,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     chunk_sizer.log_df(trace_label, "indiv_utils", indiv_utils)
 
@@ -1241,7 +1241,7 @@ def _run_cdap(
             trace_label=trace_label,
             add_joint_tour_utility=add_joint_tour_utility,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         hh_choices_list.append(choices)
@@ -1328,7 +1328,7 @@ def run_cdap(
     trace_hh_id=None,
     trace_label=None,
     add_joint_tour_utility=False,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Choose individual activity patterns for persons.
@@ -1392,7 +1392,7 @@ def run_cdap(
                 chunk_trace_label,
                 add_joint_tour_utility,
                 chunk_sizer=chunk_sizer,
-                sharrow_settings=sharrow_settings,
+                compute_settings=compute_settings,
             )
         else:
             cdap_results = _run_cdap(
@@ -1407,7 +1407,7 @@ def run_cdap(
                 chunk_trace_label,
                 add_joint_tour_utility,
                 chunk_sizer=chunk_sizer,
-                sharrow_settings=sharrow_settings,
+                compute_settings=compute_settings,
             )
 
         result_list.append(cdap_results)

--- a/activitysim/abm/models/util/cdap.py
+++ b/activitysim/abm/models/util/cdap.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from activitysim.core import chunk, logit, simulate, tracing, workflow
+from activitysim.core.configuration.base import SharrowSettings
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,7 @@ def individual_utilities(
     trace_label=None,
     *,
     chunk_sizer,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Calculate CDAP utilities for all individuals.
@@ -211,6 +213,7 @@ def individual_utilities(
         locals_d,
         trace_label=trace_label,
         chunk_sizer=chunk_sizer,
+        sharrow_settings=sharrow_settings,
     )
 
     # add columns from persons to facilitate building household interactions
@@ -909,6 +912,7 @@ def household_activity_choices(
     add_joint_tour_utility=False,
     *,
     chunk_sizer,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Calculate household utilities for each activity pattern alternative for households of hhsize
@@ -957,7 +961,12 @@ def household_activity_choices(
         )
 
         utils = simulate.eval_utilities(
-            state, spec, choosers, trace_label=trace_label, chunk_sizer=chunk_sizer
+            state,
+            spec,
+            choosers,
+            trace_label=trace_label,
+            chunk_sizer=chunk_sizer,
+            sharrow_settings=sharrow_settings,
         )
 
     if len(utils.index) == 0:
@@ -981,6 +990,7 @@ def household_activity_choices(
             choosers,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
+            sharrow_settings=sharrow_settings,
         )
 
         # add joint util to util
@@ -1183,6 +1193,7 @@ def _run_cdap(
     add_joint_tour_utility,
     *,
     chunk_sizer,
+    sharrow_settings: SharrowSettings | None = None,
 ) -> pd.DataFrame | tuple:
     """
     Implements core run_cdap functionality on persons df (or chunked subset thereof)
@@ -1213,6 +1224,7 @@ def _run_cdap(
         trace_hh_id,
         trace_label,
         chunk_sizer=chunk_sizer,
+        sharrow_settings=sharrow_settings,
     )
     chunk_sizer.log_df(trace_label, "indiv_utils", indiv_utils)
 
@@ -1229,6 +1241,7 @@ def _run_cdap(
             trace_label=trace_label,
             add_joint_tour_utility=add_joint_tour_utility,
             chunk_sizer=chunk_sizer,
+            sharrow_settings=sharrow_settings,
         )
 
         hh_choices_list.append(choices)
@@ -1315,6 +1328,7 @@ def run_cdap(
     trace_hh_id=None,
     trace_label=None,
     add_joint_tour_utility=False,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Choose individual activity patterns for persons.
@@ -1378,6 +1392,7 @@ def run_cdap(
                 chunk_trace_label,
                 add_joint_tour_utility,
                 chunk_sizer=chunk_sizer,
+                sharrow_settings=sharrow_settings,
             )
         else:
             cdap_results = _run_cdap(
@@ -1392,6 +1407,7 @@ def run_cdap(
                 chunk_trace_label,
                 add_joint_tour_utility,
                 chunk_sizer=chunk_sizer,
+                sharrow_settings=sharrow_settings,
             )
 
         result_list.append(cdap_results)

--- a/activitysim/abm/models/util/mode.py
+++ b/activitysim/abm/models/util/mode.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pandas as pd
 
 from activitysim.core import config, expressions, simulate, workflow
-from activitysim.core.configuration.base import SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings
 from activitysim.core.configuration.logit import TourModeComponentSettings
 from activitysim.core.estimation import Estimator
 
@@ -35,7 +35,7 @@ def mode_choice_simulate(
     trace_choice_name,
     trace_column_names=None,
     estimator: Optional[Estimator] = None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     common method for  both tour_mode_choice and trip_mode_choice
@@ -53,7 +53,7 @@ def mode_choice_simulate(
     trace_label
     trace_choice_name
     estimator
-    sharrow_settings : SharrowSettings
+    compute_settings : ComputeSettings
 
     Returns
     -------
@@ -73,7 +73,7 @@ def mode_choice_simulate(
         trace_choice_name=trace_choice_name,
         estimator=estimator,
         trace_column_names=trace_column_names,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
 
     # for consistency, always return dataframe, whether or not logsums were requested
@@ -174,7 +174,7 @@ def run_tour_mode_choice_simulate(
         trace_choice_name=trace_choice_name,
         trace_column_names=trace_column_names,
         estimator=estimator,
-        sharrow_settings=model_settings.sharrow_settings,
+        compute_settings=model_settings.compute_settings,
     )
 
     return choices

--- a/activitysim/abm/models/util/mode.py
+++ b/activitysim/abm/models/util/mode.py
@@ -34,6 +34,7 @@ def mode_choice_simulate(
     trace_choice_name,
     trace_column_names=None,
     estimator: Optional[Estimator] = None,
+    fastmath: bool = True,
 ):
     """
     common method for  both tour_mode_choice and trip_mode_choice
@@ -51,6 +52,7 @@ def mode_choice_simulate(
     trace_label
     trace_choice_name
     estimator
+    fastmath
 
     Returns
     -------
@@ -70,6 +72,7 @@ def mode_choice_simulate(
         trace_choice_name=trace_choice_name,
         estimator=estimator,
         trace_column_names=trace_column_names,
+        fastmath=fastmath,
     )
 
     # for consistency, always return dataframe, whether or not logsums were requested
@@ -170,6 +173,7 @@ def run_tour_mode_choice_simulate(
         trace_choice_name=trace_choice_name,
         trace_column_names=trace_column_names,
         estimator=estimator,
+        fastmath=model_settings.sharrow_fastmath,
     )
 
     return choices

--- a/activitysim/abm/models/util/mode.py
+++ b/activitysim/abm/models/util/mode.py
@@ -9,6 +9,7 @@ from typing import Optional
 import pandas as pd
 
 from activitysim.core import config, expressions, simulate, workflow
+from activitysim.core.configuration.base import SharrowSettings
 from activitysim.core.configuration.logit import TourModeComponentSettings
 from activitysim.core.estimation import Estimator
 
@@ -34,7 +35,7 @@ def mode_choice_simulate(
     trace_choice_name,
     trace_column_names=None,
     estimator: Optional[Estimator] = None,
-    fastmath: bool = True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     common method for  both tour_mode_choice and trip_mode_choice
@@ -52,7 +53,7 @@ def mode_choice_simulate(
     trace_label
     trace_choice_name
     estimator
-    fastmath
+    sharrow_settings : SharrowSettings
 
     Returns
     -------
@@ -72,7 +73,7 @@ def mode_choice_simulate(
         trace_choice_name=trace_choice_name,
         estimator=estimator,
         trace_column_names=trace_column_names,
-        fastmath=fastmath,
+        sharrow_settings=sharrow_settings,
     )
 
     # for consistency, always return dataframe, whether or not logsums were requested
@@ -173,7 +174,7 @@ def run_tour_mode_choice_simulate(
         trace_choice_name=trace_choice_name,
         trace_column_names=trace_column_names,
         estimator=estimator,
-        fastmath=model_settings.sharrow_fastmath,
+        sharrow_settings=model_settings.sharrow_settings,
     )
 
     return choices

--- a/activitysim/abm/models/util/tour_destination.py
+++ b/activitysim/abm/models/util/tour_destination.py
@@ -123,6 +123,9 @@ def _destination_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer=zone_layer,
+        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+            "sample"
+        ),
     )
 
     # if special person id is passed

--- a/activitysim/abm/models/util/tour_destination.py
+++ b/activitysim/abm/models/util/tour_destination.py
@@ -123,7 +123,7 @@ def _destination_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer=zone_layer,
-        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+        compute_settings=model_settings.compute_settings.subcomponent_settings(
             "sample"
         ),
     )

--- a/activitysim/abm/models/util/tour_frequency.py
+++ b/activitysim/abm/models/util/tour_frequency.py
@@ -637,7 +637,7 @@ class JointTourFreqCompAlts(PydanticReadable):
     COMPOSITION: JointTourFreqCompContent
 
 
-class JointTourFreqCompSettings(LogitComponentSettings):
+class JointTourFreqCompSettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for joint tour frequency and composition.
     """

--- a/activitysim/abm/models/util/tour_od.py
+++ b/activitysim/abm/models/util/tour_od.py
@@ -216,7 +216,7 @@ def _od_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer="taz",
-        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+        compute_settings=model_settings.compute_settings.subcomponent_settings(
             "sample"
         ),
     )

--- a/activitysim/abm/models/util/tour_od.py
+++ b/activitysim/abm/models/util/tour_od.py
@@ -216,6 +216,9 @@ def _od_sample(
         chunk_tag=chunk_tag,
         trace_label=trace_label,
         zone_layer="taz",
+        sharrow_settings=model_settings.sharrow_settings.subcomponent_settings(
+            "sample"
+        ),
     )
 
     return choices

--- a/activitysim/abm/models/util/tour_scheduling.py
+++ b/activitysim/abm/models/util/tour_scheduling.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 def run_tour_scheduling(
     state: workflow.State,
-    model_name,
-    chooser_tours,
-    persons_merged,
-    tdd_alts,
-    tour_segment_col,
+    model_name: str,
+    chooser_tours: pd.DataFrame,
+    persons_merged: pd.DataFrame,
+    tdd_alts: pd.DataFrame,
+    tour_segment_col: str,
 ):
     trace_label = model_name
     model_settings_file_name = f"{model_name}.yaml"
@@ -70,7 +70,7 @@ def run_tour_scheduling(
         # load segmented specs
         spec_segment_settings = model_settings.SPEC_SEGMENTS
         specs = {}
-        sharrow_skips = {}
+        sharrow_settings = {}
         for spec_segment_name, spec_settings in spec_segment_settings.items():
             bundle_name = f"{model_name}_{spec_segment_name}"
 
@@ -85,7 +85,9 @@ def run_tour_scheduling(
             specs[spec_segment_name] = simulate.eval_coefficients(
                 state, model_spec, coefficients_df, estimator
             )
-            sharrow_skips[spec_segment_name] = spec_settings.sharrow_skip
+            sharrow_settings[
+                spec_segment_name
+            ] = spec_settings.sharrow_settings.subcomponent_settings(spec_segment_name)
 
             if estimator:
                 estimators[spec_segment_name] = estimator  # add to local list
@@ -100,7 +102,7 @@ def run_tour_scheduling(
             tour_segments[tour_segment_name] = {}
             tour_segments[tour_segment_name]["spec_segment_name"] = spec_segment_name
             tour_segments[tour_segment_name]["spec"] = specs[spec_segment_name]
-            tour_segments[tour_segment_name]["sharrow_skip"] = sharrow_skips[
+            tour_segments[tour_segment_name]["sharrow_settings"] = sharrow_settings[
                 spec_segment_name
             ]
             tour_segments[tour_segment_name]["estimator"] = estimators.get(
@@ -123,7 +125,6 @@ def run_tour_scheduling(
 
         spec_file_name = model_settings.SPEC
         model_spec = state.filesystem.read_model_spec(file_name=spec_file_name)
-        sharrow_skip = model_settings.sharrow_skip
         coefficients_df = state.filesystem.read_model_coefficients(model_settings)
         model_spec = simulate.eval_coefficients(
             state, model_spec, coefficients_df, estimator
@@ -139,7 +140,7 @@ def run_tour_scheduling(
         tour_segments = {
             "spec": model_spec,
             "estimator": estimator,
-            "sharrow_skip": sharrow_skip,
+            "sharrow_settings": model_settings.sharrow_settings,
         }
 
     if estimators:

--- a/activitysim/abm/models/util/tour_scheduling.py
+++ b/activitysim/abm/models/util/tour_scheduling.py
@@ -70,7 +70,7 @@ def run_tour_scheduling(
         # load segmented specs
         spec_segment_settings = model_settings.SPEC_SEGMENTS
         specs = {}
-        sharrow_settings = {}
+        compute_settings = {}
         for spec_segment_name, spec_settings in spec_segment_settings.items():
             bundle_name = f"{model_name}_{spec_segment_name}"
 
@@ -85,9 +85,9 @@ def run_tour_scheduling(
             specs[spec_segment_name] = simulate.eval_coefficients(
                 state, model_spec, coefficients_df, estimator
             )
-            sharrow_settings[
+            compute_settings[
                 spec_segment_name
-            ] = spec_settings.sharrow_settings.subcomponent_settings(spec_segment_name)
+            ] = spec_settings.compute_settings.subcomponent_settings(spec_segment_name)
 
             if estimator:
                 estimators[spec_segment_name] = estimator  # add to local list
@@ -102,7 +102,7 @@ def run_tour_scheduling(
             tour_segments[tour_segment_name] = {}
             tour_segments[tour_segment_name]["spec_segment_name"] = spec_segment_name
             tour_segments[tour_segment_name]["spec"] = specs[spec_segment_name]
-            tour_segments[tour_segment_name]["sharrow_settings"] = sharrow_settings[
+            tour_segments[tour_segment_name]["compute_settings"] = compute_settings[
                 spec_segment_name
             ]
             tour_segments[tour_segment_name]["estimator"] = estimators.get(
@@ -140,7 +140,7 @@ def run_tour_scheduling(
         tour_segments = {
             "spec": model_spec,
             "estimator": estimator,
-            "sharrow_settings": model_settings.sharrow_settings,
+            "compute_settings": model_settings.compute_settings,
         }
 
     if estimators:

--- a/activitysim/abm/models/util/vectorize_tour_scheduling.py
+++ b/activitysim/abm/models/util/vectorize_tour_scheduling.py
@@ -14,7 +14,7 @@ from activitysim.abm.models.tour_mode_choice import TourModeComponentSettings
 from activitysim.core import chunk, config, expressions, los, simulate
 from activitysim.core import timetable as tt
 from activitysim.core import tracing, workflow
-from activitysim.core.configuration.base import PreprocessorSettings, SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings, PreprocessorSettings
 from activitysim.core.configuration.logit import LogitComponentSettings
 from activitysim.core.interaction_sample_simulate import interaction_sample_simulate
 from activitysim.core.util import reindex
@@ -224,7 +224,7 @@ def _compute_logsums(
             locals_d=locals_dict,
             chunk_size=0,
             trace_label=trace_label,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
 
     return logsums
@@ -707,7 +707,7 @@ def _schedule_tours(
     estimator,
     tour_trace_label,
     *,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
     chunk_sizer: chunk.ChunkSizer,
 ):
     """
@@ -857,7 +857,7 @@ def _schedule_tours(
         chunk_size=0,
         trace_label=tour_trace_label,
         estimator=estimator,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     chunk_sizer.log_df(tour_trace_label, "choices", choices)
 
@@ -888,7 +888,7 @@ def schedule_tours(
     chunk_size,
     tour_trace_label,
     tour_chunk_tag,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     chunking wrapper for _schedule_tours
@@ -946,7 +946,7 @@ def schedule_tours(
             tour_owner_id_col,
             estimator,
             tour_trace_label=chunk_trace_label,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
             chunk_sizer=chunk_sizer,
         )
 
@@ -1099,7 +1099,7 @@ def vectorize_tour_scheduling(
                     chunk_size=chunk_size,
                     tour_trace_label=segment_trace_label,
                     tour_chunk_tag=segment_chunk_tag,
-                    sharrow_settings=tour_segment_info.get("sharrow_settings"),
+                    compute_settings=tour_segment_info.get("compute_settings"),
                 )
 
                 choice_list.append(choices)
@@ -1129,7 +1129,7 @@ def vectorize_tour_scheduling(
                 chunk_size=chunk_size,
                 tour_trace_label=tour_trace_label,
                 tour_chunk_tag=tour_chunk_tag,
-                sharrow_settings=tour_segments.get("sharrow_settings"),
+                compute_settings=tour_segments.get("compute_settings"),
             )
 
             choice_list.append(choices)
@@ -1149,7 +1149,7 @@ def vectorize_subtour_scheduling(
     estimator,
     chunk_size=0,
     trace_label=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Like vectorize_tour_scheduling but specifically for atwork subtours
@@ -1248,7 +1248,7 @@ def vectorize_subtour_scheduling(
             state.settings.chunk_size,
             tour_trace_label,
             tour_chunk_tag,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         choice_list.append(choices)
@@ -1303,7 +1303,7 @@ def vectorize_joint_tour_scheduling(
     estimator,
     chunk_size=0,
     trace_label=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Like vectorize_tour_scheduling but specifically for joint tours
@@ -1396,7 +1396,7 @@ def vectorize_joint_tour_scheduling(
             chunk_size,
             tour_trace_label,
             tour_chunk_tag,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         # - update timetables of all joint tour participants

--- a/activitysim/abm/models/util/vectorize_tour_scheduling.py
+++ b/activitysim/abm/models/util/vectorize_tour_scheduling.py
@@ -224,6 +224,7 @@ def _compute_logsums(
             locals_d=locals_dict,
             chunk_size=0,
             trace_label=trace_label,
+            sharrow_settings=model_settings.sharrow_settings,
         )
 
     return logsums

--- a/activitysim/abm/models/vehicle_allocation.py
+++ b/activitysim/abm/models/vehicle_allocation.py
@@ -247,7 +247,7 @@ def vehicle_allocation(
             trace_label=trace_label,
             trace_choice_name="vehicle_allocation",
             estimator=estimator,
-            fastmath=model_settings.sharrow_fastmath,
+            sharrow_settings=model_settings.sharrow_settings,
         )
 
         # matching alt names to choices

--- a/activitysim/abm/models/vehicle_allocation.py
+++ b/activitysim/abm/models/vehicle_allocation.py
@@ -247,7 +247,7 @@ def vehicle_allocation(
             trace_label=trace_label,
             trace_choice_name="vehicle_allocation",
             estimator=estimator,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
 
         # matching alt names to choices

--- a/activitysim/abm/models/vehicle_allocation.py
+++ b/activitysim/abm/models/vehicle_allocation.py
@@ -247,6 +247,7 @@ def vehicle_allocation(
             trace_label=trace_label,
             trace_choice_name="vehicle_allocation",
             estimator=estimator,
+            fastmath=model_settings.sharrow_fastmath,
         )
 
         # matching alt names to choices

--- a/activitysim/abm/models/vehicle_type_choice.py
+++ b/activitysim/abm/models/vehicle_type_choice.py
@@ -485,7 +485,7 @@ def iterate_vehicle_type_choice(
                 trace_choice_name="vehicle_type",
                 estimator=estimator,
                 explicit_chunk_size=model_settings.explicit_chunk,
-                sharrow_settings=model_settings.sharrow_settings,
+                compute_settings=model_settings.compute_settings,
             )
 
         # otherwise, "simple simulation" should suffice, with a model spec that enumerates
@@ -501,7 +501,7 @@ def iterate_vehicle_type_choice(
                 trace_label=trace_label,
                 trace_choice_name="vehicle_type",
                 estimator=estimator,
-                sharrow_settings=model_settings.sharrow_settings,
+                compute_settings=model_settings.compute_settings,
             )
         else:
             raise NotImplementedError(simulation_type)

--- a/activitysim/abm/models/vehicle_type_choice.py
+++ b/activitysim/abm/models/vehicle_type_choice.py
@@ -556,7 +556,7 @@ def iterate_vehicle_type_choice(
     return all_choices, all_choosers
 
 
-class VehicleTypeChoiceSettings(LogitComponentSettings):
+class VehicleTypeChoiceSettings(LogitComponentSettings, extra="forbid"):
     """
     Settings for the `vehicle_type_choice` component.
     """

--- a/activitysim/abm/models/vehicle_type_choice.py
+++ b/activitysim/abm/models/vehicle_type_choice.py
@@ -485,7 +485,7 @@ def iterate_vehicle_type_choice(
                 trace_choice_name="vehicle_type",
                 estimator=estimator,
                 explicit_chunk_size=model_settings.explicit_chunk,
-                fastmath=model_settings.sharrow_fastmath,
+                sharrow_settings=model_settings.sharrow_settings,
             )
 
         # otherwise, "simple simulation" should suffice, with a model spec that enumerates
@@ -501,7 +501,7 @@ def iterate_vehicle_type_choice(
                 trace_label=trace_label,
                 trace_choice_name="vehicle_type",
                 estimator=estimator,
-                fastmath=model_settings.sharrow_fastmath,
+                sharrow_settings=model_settings.sharrow_settings,
             )
         else:
             raise NotImplementedError(simulation_type)

--- a/activitysim/abm/models/vehicle_type_choice.py
+++ b/activitysim/abm/models/vehicle_type_choice.py
@@ -485,6 +485,7 @@ def iterate_vehicle_type_choice(
                 trace_choice_name="vehicle_type",
                 estimator=estimator,
                 explicit_chunk_size=model_settings.explicit_chunk,
+                fastmath=model_settings.sharrow_fastmath,
             )
 
         # otherwise, "simple simulation" should suffice, with a model spec that enumerates
@@ -500,6 +501,7 @@ def iterate_vehicle_type_choice(
                 trace_label=trace_label,
                 trace_choice_name="vehicle_type",
                 estimator=estimator,
+                fastmath=model_settings.sharrow_fastmath,
             )
         else:
             raise NotImplementedError(simulation_type)

--- a/activitysim/abm/models/work_from_home.py
+++ b/activitysim/abm/models/work_from_home.py
@@ -50,9 +50,6 @@ class WorkFromHomeSettings(LogitComponentSettings, extra="forbid"):
     WORK_FROM_HOME_TARGET_PERCENT_TOLERANCE: float = None
     """Setting to set work from home target percent tolerance."""
 
-    sharrow_skip: bool = False
-    """Setting to skip sharrow."""
-
     DEST_CHOICE_COLUMN_NAME: str = "workplace_zone_id"
     """Column name in persons dataframe to specify the workplace zone id. """
 
@@ -140,9 +137,6 @@ def work_from_home(
             state, model_spec, coefficients_df, estimator
         )
 
-        if model_settings.sharrow_skip:
-            constants["disable_sharrow"] = True
-
         choices = simulate.simple_simulate(
             state,
             choosers=choosers,
@@ -152,7 +146,7 @@ def work_from_home(
             trace_label=trace_label,
             trace_choice_name="work_from_home",
             estimator=estimator,
-            fastmath=model_settings.sharrow_fastmath,
+            sharrow_settings=model_settings.sharrow_settings,
         )
 
         if iterations_target_percent is not None:

--- a/activitysim/abm/models/work_from_home.py
+++ b/activitysim/abm/models/work_from_home.py
@@ -152,6 +152,7 @@ def work_from_home(
             trace_label=trace_label,
             trace_choice_name="work_from_home",
             estimator=estimator,
+            fastmath=model_settings.sharrow_fastmath,
         )
 
         if iterations_target_percent is not None:

--- a/activitysim/abm/models/work_from_home.py
+++ b/activitysim/abm/models/work_from_home.py
@@ -146,7 +146,7 @@ def work_from_home(
             trace_label=trace_label,
             trace_choice_name="work_from_home",
             estimator=estimator,
-            sharrow_settings=model_settings.sharrow_settings,
+            compute_settings=model_settings.compute_settings,
         )
 
         if iterations_target_percent is not None:

--- a/activitysim/core/configuration/base.py
+++ b/activitysim/core/configuration/base.py
@@ -235,7 +235,7 @@ class ComputeSettings(PydanticBase):
         )
 
 
-class PydanticSharrow(PydanticReadable):
+class PydanticCompute(PydanticReadable):
     """Base class for component settings that include optional sharrow controls."""
 
     compute_settings: ComputeSettings = ComputeSettings()

--- a/activitysim/core/configuration/base.py
+++ b/activitysim/core/configuration/base.py
@@ -130,12 +130,12 @@ class PreprocessorSettings(PydanticBase):
     """
 
 
-class SharrowSettings(PydanticBase):
+class ComputeSettings(PydanticBase):
     """
     Sharrow settings for a component.
     """
 
-    skip: bool | dict[str, bool] = False
+    sharrow_skip: bool | dict[str, bool] = False
     """Skip sharrow when evaluating this component.
 
     This overrides the global sharrow setting, and is useful if you want to skip
@@ -143,19 +143,19 @@ class SharrowSettings(PydanticBase):
     not compatible with sharrow or if the sharrow performance is known to be
     poor on this component.
 
-    When a component has multiple subcomponents, the `skip` setting can be
+    When a component has multiple subcomponents, the `sharrow_skip` setting can be
     a dictionary that maps the names of the subcomponents to boolean values.
     For example, to skip sharrow for an OUTBOUND and OUTBOUND_COND subcomponent
     but not the INBOUND subcomponent, use the following setting:
 
     ```yaml
-    skip:
+    sharrow_skip:
         OUTBOUND: true
         INBOUND: false
         OUTBOUND_COND: true
     ```
 
-    Alternatively, even for components with multiple subcomponents, the `skip`
+    Alternatively, even for components with multiple subcomponents, the `sharrow_skip`
     value can be a single boolean true or false, which will be used for all
     subcomponents.
 
@@ -203,10 +203,10 @@ class SharrowSettings(PydanticBase):
 
     def should_skip(self, subcomponent: str) -> bool:
         """Check if sharrow should be skipped for a particular subcomponent."""
-        if isinstance(self.skip, dict):
-            return self.skip.get(subcomponent, False)
+        if isinstance(self.sharrow_skip, dict):
+            return self.sharrow_skip.get(subcomponent, False)
         else:
-            return bool(self.skip)
+            return bool(self.sharrow_skip)
 
     @contextmanager
     def pandas_option_context(self):
@@ -224,10 +224,10 @@ class SharrowSettings(PydanticBase):
         else:
             yield
 
-    def subcomponent_settings(self, subcomponent: str) -> SharrowSettings:
+    def subcomponent_settings(self, subcomponent: str) -> ComputeSettings:
         """Get the sharrow settings for a particular subcomponent."""
-        return SharrowSettings(
-            skip=self.should_skip(subcomponent),
+        return ComputeSettings(
+            sharrow_skip=self.should_skip(subcomponent),
             fastmath=self.fastmath,
             use_bottleneck=self.use_bottleneck,
             use_numexpr=self.use_numexpr,
@@ -238,5 +238,5 @@ class SharrowSettings(PydanticBase):
 class PydanticSharrow(PydanticReadable):
     """Base class for component settings that include optional sharrow controls."""
 
-    sharrow_settings: SharrowSettings = SharrowSettings()
+    compute_settings: ComputeSettings = ComputeSettings()
     """Sharrow settings for this component."""

--- a/activitysim/core/configuration/logit.py
+++ b/activitysim/core/configuration/logit.py
@@ -8,7 +8,7 @@ import pydantic
 from pydantic import BaseModel as PydanticBase
 from pydantic import model_validator, validator
 
-from activitysim.core.configuration.base import PreprocessorSettings, PydanticSharrow
+from activitysim.core.configuration.base import PreprocessorSettings, PydanticCompute
 
 
 class LogitNestSpec(PydanticBase):
@@ -45,7 +45,7 @@ class LogitNestSpec(PydanticBase):
         return coefficient_value
 
 
-class BaseLogitComponentSettings(PydanticSharrow):
+class BaseLogitComponentSettings(PydanticCompute):
     """
     Base configuration class for components that are logit models.
 

--- a/activitysim/core/configuration/logit.py
+++ b/activitysim/core/configuration/logit.py
@@ -77,33 +77,33 @@ class BaseLogitComponentSettings(PydanticSharrow):
     CONSTANTS: dict[str, Any] = {}
     """Named constants usable in the utility expressions."""
 
-    # sharrow_skip is deprecated in factor of sharrow_settings.skip
+    # sharrow_skip is deprecated in factor of compute_settings.sharrow_skip
     @model_validator(mode="before")
     @classmethod
     def update_sharrow_skip(cls, data: Any) -> Any:
         if isinstance(data, dict):
             if "sharrow_skip" in data:
-                if "sharrow_settings" not in data:
+                if "compute_settings" not in data:
                     # move to new format
-                    data["sharrow_settings"] = {"skip": data["sharrow_skip"]}
+                    data["compute_settings"] = {"sharrow_skip": data["sharrow_skip"]}
                     del data["sharrow_skip"]
                     warnings.warn(
-                        "sharrow_skip is deprecated in favor of sharrow_settings.skip",
+                        "sharrow_skip is deprecated in favor of compute_settings.sharrow_skip",
                         DeprecationWarning,
                     )
                 elif (
-                    isinstance(data["sharrow_settings"], dict)
-                    and "skip" not in data["sharrow_settings"]
+                    isinstance(data["compute_settings"], dict)
+                    and "sharrow_skip" not in data["compute_settings"]
                 ):
-                    data["sharrow_settings"]["skip"] = data["sharrow_skip"]
+                    data["compute_settings"]["sharrow_skip"] = data["sharrow_skip"]
                     del data["sharrow_skip"]
                     warnings.warn(
-                        "sharrow_skip is deprecated in favor of sharrow_settings.skip",
+                        "sharrow_skip is deprecated in favor of compute_settings.skip",
                         DeprecationWarning,
                     )
-                elif "skip" in data["sharrow_settings"]:
+                elif "sharrow_skip" in data["compute_settings"]:
                     raise ValueError(
-                        "sharrow_skip and sharrow_settings.skip cannot both be defined"
+                        "sharrow_skip and compute_settings.sharrow_skip cannot both be defined"
                     )
         return data
 

--- a/activitysim/core/configuration/logit.py
+++ b/activitysim/core/configuration/logit.py
@@ -84,19 +84,27 @@ class BaseLogitComponentSettings(PydanticSharrow):
         if isinstance(data, dict):
             if "sharrow_skip" in data:
                 if "sharrow_settings" not in data:
-                    data["sharrow_settings"] = {}
+                    # move to new format
+                    data["sharrow_settings"] = {"skip": data["sharrow_skip"]}
+                    del data["sharrow_skip"]
+                    warnings.warn(
+                        "sharrow_skip is deprecated in favor of sharrow_settings.skip",
+                        DeprecationWarning,
+                    )
+                elif (
+                    isinstance(data["sharrow_settings"], dict)
+                    and "skip" not in data["sharrow_settings"]
+                ):
+                    data["sharrow_settings"]["skip"] = data["sharrow_skip"]
+                    del data["sharrow_skip"]
+                    warnings.warn(
+                        "sharrow_skip is deprecated in favor of sharrow_settings.skip",
+                        DeprecationWarning,
+                    )
                 elif "skip" in data["sharrow_settings"]:
                     raise ValueError(
                         "sharrow_skip and sharrow_settings.skip cannot both be defined"
                     )
-            else:
-                # move to new format
-                data["sharrow_settings"] = {"skip": data["sharrow_skip"]}
-                del data["sharrow_skip"]
-                warnings.warn(
-                    "sharrow_skip is deprecated in favor of sharrow_settings.skip",
-                    DeprecationWarning,
-                )
         return data
 
 

--- a/activitysim/core/configuration/logit.py
+++ b/activitysim/core/configuration/logit.py
@@ -163,7 +163,7 @@ class LogitComponentSettings(BaseLogitComponentSettings):
         return nests
 
 
-class TemplatedLogitComponentSettings(LogitComponentSettings):
+class TemplatedLogitComponentSettings(LogitComponentSettings, extra="forbid"):
     """
     Base configuration for segmented logit models with a coefficient template.
     """

--- a/activitysim/core/configuration/logit.py
+++ b/activitysim/core/configuration/logit.py
@@ -78,6 +78,17 @@ class BaseLogitComponentSettings(PydanticReadable):
     sharrow_skip: bool = False
     """Skip sharrow when evaluating this component."""
 
+    sharrow_fastmath: bool = True
+    """Use fastmath when evaluating this component with sharrow.
+
+    The fastmath option can be used to speed up the evaluation of expressions in
+    this component's spec files, but it does so by making some simplifying
+    assumptions about the math, e.g. that neither inputs nor outputs of any
+    computations are NaN or Inf.  This can lead to errors when the assumptions
+    are violated.  If running in sharrow test mode generates errors, try turning
+    this setting off.
+    """
+
 
 class LogitComponentSettings(BaseLogitComponentSettings):
     """

--- a/activitysim/core/flow.py
+++ b/activitysim/core/flow.py
@@ -142,6 +142,7 @@ def get_flow(
     choosers=None,
     interacts=None,
     zone_layer=None,
+    fastmath=True,
 ):
     extra_vars = only_simple(local_d)
     orig_col_name = local_d.get("orig_col_name", None)
@@ -184,6 +185,7 @@ def get_flow(
         zone_layer=zone_layer,
         aux_vars=aux_vars,
         primary_origin_col_name=primary_origin_col_name,
+        fastmath=fastmath,
     )
     flow.tree.aux_vars = aux_vars
     return flow
@@ -465,6 +467,7 @@ def new_flow(
     zone_layer=None,
     aux_vars=None,
     primary_origin_col_name=None,
+    fastmath=True,
 ):
     """
     Setup a new sharrow flow.
@@ -516,6 +519,11 @@ def new_flow(
     aux_vars : Mapping
         Extra values that are available to expressions and which are written
         only by reference into compiled code (and thus can be changed later).
+    fastmath : bool, default True
+        Whether to use fastmath in the numba compiled code. Leaving this option
+        set to "True" is generally a good idea to maximize performance, but it
+        can be turned off if some expressions are not compatible with fastmath,
+        i.e. when they include "NaN" or "Inf" values.
 
     Returns
     -------
@@ -700,6 +708,7 @@ def new_flow(
             extra_hash_data=extra_hash_data,
             hashing_level=0,
             boundscheck=False,
+            fastmath=fastmath,
         )
 
 
@@ -750,6 +759,7 @@ def apply_flow(
     required=False,
     interacts=None,
     zone_layer=None,
+    fastmath=True,
 ):
     """
     Apply a sharrow flow.
@@ -779,6 +789,11 @@ def apply_flow(
         Specify which zone layer of the skims is to be used.  You cannot use the
         'maz' zone layer in a one-zone model, but you can use the 'taz' layer in
         a two- or three-zone model (e.g. for destination pre-sampling).
+    fastmath : bool, default True
+        Whether to use fastmath in the numba compiled code. Leaving this option
+        set to "True" is generally a good idea to maximize performance, but it
+        can be turned off if some expressions are not compatible with fastmath,
+        i.e. when they include "NaN" or "Inf" values.
 
     Returns
     -------
@@ -807,6 +822,7 @@ def apply_flow(
                 choosers=choosers,
                 interacts=interacts,
                 zone_layer=zone_layer,
+                fastmath=fastmath,
             )
         except ValueError as err:
             if "unable to rewrite" in str(err):

--- a/activitysim/core/flow.py
+++ b/activitysim/core/flow.py
@@ -16,7 +16,7 @@ import pandas as pd
 import activitysim.core.skim_dataset  # noqa: F401
 from activitysim import __version__
 from activitysim.core import tracing, workflow
-from activitysim.core.configuration.base import SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings
 from activitysim.core.simulate_consts import SPEC_EXPRESSION_NAME, SPEC_LABEL_NAME
 from activitysim.core.timetable import (
     sharrow_tt_adjacent_window_after,
@@ -143,7 +143,7 @@ def get_flow(
     choosers=None,
     interacts=None,
     zone_layer=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     extra_vars = only_simple(local_d)
     orig_col_name = local_d.get("orig_col_name", None)
@@ -186,7 +186,7 @@ def get_flow(
         zone_layer=zone_layer,
         aux_vars=aux_vars,
         primary_origin_col_name=primary_origin_col_name,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     flow.tree.aux_vars = aux_vars
     return flow
@@ -468,7 +468,7 @@ def new_flow(
     zone_layer=None,
     aux_vars=None,
     primary_origin_col_name=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Setup a new sharrow flow.
@@ -520,15 +520,15 @@ def new_flow(
     aux_vars : Mapping
         Extra values that are available to expressions and which are written
         only by reference into compiled code (and thus can be changed later).
-    sharrow_settings : SharrowSettings, optional
+    compute_settings : ComputeSettings, optional
         Settings for the sharrow flow.
 
     Returns
     -------
     sharrow.Flow
     """
-    if sharrow_settings is None:
-        sharrow_settings = SharrowSettings()
+    if compute_settings is None:
+        compute_settings = ComputeSettings()
     with logtime(f"setting up flow {trace_label}"):
         if choosers is None:
             chooser_cols = []
@@ -707,7 +707,7 @@ def new_flow(
             extra_hash_data=extra_hash_data,
             hashing_level=0,
             boundscheck=False,
-            fastmath=sharrow_settings.fastmath,
+            fastmath=compute_settings.fastmath,
         )
 
 
@@ -758,7 +758,7 @@ def apply_flow(
     required=False,
     interacts=None,
     zone_layer=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Apply a sharrow flow.
@@ -788,7 +788,7 @@ def apply_flow(
         Specify which zone layer of the skims is to be used.  You cannot use the
         'maz' zone layer in a one-zone model, but you can use the 'taz' layer in
         a two- or three-zone model (e.g. for destination pre-sampling).
-    sharrow_settings : SharrowSettings, optional
+    compute_settings : ComputeSettings, optional
         Settings for the sharrow flow, including for skipping and fastmath.
 
     Returns
@@ -818,7 +818,7 @@ def apply_flow(
                 choosers=choosers,
                 interacts=interacts,
                 zone_layer=zone_layer,
-                sharrow_settings=sharrow_settings,
+                compute_settings=compute_settings,
             )
         except ValueError as err:
             if "unable to rewrite" in str(err):

--- a/activitysim/core/interaction_sample.py
+++ b/activitysim/core/interaction_sample.py
@@ -310,6 +310,7 @@ def _interaction_sample(
             estimator=None,
             log_alt_losers=log_alt_losers,
             zone_layer=zone_layer,
+            sharrow_settings=SharrowSettings(skip=True),
         )
         chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
 

--- a/activitysim/core/interaction_sample.py
+++ b/activitysim/core/interaction_sample.py
@@ -15,7 +15,7 @@ from activitysim.core import (
     tracing,
     workflow,
 )
-from activitysim.core.configuration.base import SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings
 from activitysim.core.skim_dataset import DatasetWrapper
 from activitysim.core.skim_dictionary import SkimWrapper
 
@@ -133,7 +133,7 @@ def _interaction_sample(
     trace_label=None,
     zone_layer=None,
     chunk_sizer=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a MNL simulation in the situation in which alternatives must
@@ -180,7 +180,7 @@ def _interaction_sample(
         'maz' zone layer in a one-zone model, but you can use the 'taz' layer in
         a two- or three-zone model (e.g. for destination pre-sampling).
 
-    sharrow_settings : SharrowSettings, optional
+    compute_settings : ComputeSettings, optional
         Settings to use if compiling with sharrow
 
     Returns
@@ -228,7 +228,9 @@ def _interaction_sample(
     chooser_index_id = interaction_simulate.ALT_CHOOSER_ID if log_alt_losers else None
 
     sharrow_enabled = state.settings.sharrow
-    if sharrow_settings is not None and sharrow_settings.skip:
+    if compute_settings is None:
+        compute_settings = ComputeSettings()
+    if compute_settings.sharrow_skip:
         sharrow_enabled = False
 
     # - cross join choosers and alternatives (cartesian product)
@@ -253,7 +255,7 @@ def _interaction_sample(
             log_alt_losers=log_alt_losers,
             extra_data=alternatives,
             zone_layer=zone_layer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
         chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
         if sharrow_enabled == "test" or True:
@@ -310,7 +312,7 @@ def _interaction_sample(
             estimator=None,
             log_alt_losers=log_alt_losers,
             zone_layer=zone_layer,
-            sharrow_settings=SharrowSettings(skip=True),
+            compute_settings=ComputeSettings(sharrow_skip=True),
         )
         chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
 
@@ -530,7 +532,7 @@ def interaction_sample(
     chunk_tag: str | None = None,
     trace_label: str | None = None,
     zone_layer: str | None = None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a simulation in the situation in which alternatives must
@@ -626,7 +628,7 @@ def interaction_sample(
             trace_label=chunk_trace_label,
             zone_layer=zone_layer,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         if choices.shape[0] > 0:

--- a/activitysim/core/interaction_sample.py
+++ b/activitysim/core/interaction_sample.py
@@ -15,6 +15,7 @@ from activitysim.core import (
     tracing,
     workflow,
 )
+from activitysim.core.configuration.base import SharrowSettings
 from activitysim.core.skim_dataset import DatasetWrapper
 from activitysim.core.skim_dictionary import SkimWrapper
 
@@ -132,6 +133,7 @@ def _interaction_sample(
     trace_label=None,
     zone_layer=None,
     chunk_sizer=None,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run a MNL simulation in the situation in which alternatives must
@@ -178,6 +180,9 @@ def _interaction_sample(
         'maz' zone layer in a one-zone model, but you can use the 'taz' layer in
         a two- or three-zone model (e.g. for destination pre-sampling).
 
+    sharrow_settings : SharrowSettings, optional
+        Settings to use if compiling with sharrow
+
     Returns
     -------
     choices_df : pandas.DataFrame
@@ -223,6 +228,8 @@ def _interaction_sample(
     chooser_index_id = interaction_simulate.ALT_CHOOSER_ID if log_alt_losers else None
 
     sharrow_enabled = state.settings.sharrow
+    if sharrow_settings is not None and sharrow_settings.skip:
+        sharrow_enabled = False
 
     # - cross join choosers and alternatives (cartesian product)
     # for every chooser, there will be a row for each alternative
@@ -246,6 +253,7 @@ def _interaction_sample(
             log_alt_losers=log_alt_losers,
             extra_data=alternatives,
             zone_layer=zone_layer,
+            sharrow_settings=sharrow_settings,
         )
         chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
         if sharrow_enabled == "test" or True:
@@ -521,6 +529,7 @@ def interaction_sample(
     chunk_tag: str | None = None,
     trace_label: str | None = None,
     zone_layer: str | None = None,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run a simulation in the situation in which alternatives must
@@ -616,6 +625,7 @@ def interaction_sample(
             trace_label=chunk_trace_label,
             zone_layer=zone_layer,
             chunk_sizer=chunk_sizer,
+            sharrow_settings=sharrow_settings,
         )
 
         if choices.shape[0] > 0:

--- a/activitysim/core/interaction_sample_simulate.py
+++ b/activitysim/core/interaction_sample_simulate.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from activitysim.core import chunk, interaction_simulate, logit, tracing, workflow
-from activitysim.core.configuration.base import SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings
 from activitysim.core.simulate import set_skim_wrapper_targets
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ def _interaction_sample_simulate(
     skip_choice=False,
     *,
     chunk_sizer: chunk.ChunkSizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a MNL simulation in the situation in which alternatives must
@@ -183,7 +183,7 @@ def _interaction_sample_simulate(
         trace_rows,
         estimator=estimator,
         log_alt_losers=log_alt_losers,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
 
@@ -379,7 +379,7 @@ def interaction_sample_simulate(
     estimator=None,
     skip_choice=False,
     *,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a simulation in the situation in which alternatives must
@@ -469,7 +469,7 @@ def interaction_sample_simulate(
             estimator,
             skip_choice,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         result_list.append(choices)

--- a/activitysim/core/interaction_sample_simulate.py
+++ b/activitysim/core/interaction_sample_simulate.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from activitysim.core import chunk, interaction_simulate, logit, tracing, workflow
+from activitysim.core.configuration.base import SharrowSettings
 from activitysim.core.simulate import set_skim_wrapper_targets
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ def _interaction_sample_simulate(
     skip_choice=False,
     *,
     chunk_sizer: chunk.ChunkSizer,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run a MNL simulation in the situation in which alternatives must
@@ -181,6 +183,7 @@ def _interaction_sample_simulate(
         trace_rows,
         estimator=estimator,
         log_alt_losers=log_alt_losers,
+        sharrow_settings=sharrow_settings,
     )
     chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
 
@@ -375,6 +378,8 @@ def interaction_sample_simulate(
     trace_choice_name=None,
     estimator=None,
     skip_choice=False,
+    *,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run a simulation in the situation in which alternatives must
@@ -464,6 +469,7 @@ def interaction_sample_simulate(
             estimator,
             skip_choice,
             chunk_sizer=chunk_sizer,
+            sharrow_settings=sharrow_settings,
         )
 
         result_list.append(choices)

--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -89,12 +89,6 @@ def eval_interaction_utilities(
     if compute_settings.sharrow_skip:
         sharrow_enabled = False
 
-    # if locals_d is not None and locals_d.get("_sharrow_skip", False):
-    #     sharrow_enabled = False
-
-    # if trace_label.startswith("trip_destination"):
-    #     sharrow_enabled = False
-
     logger.info(f"{trace_label} sharrow_enabled is {sharrow_enabled}")
 
     trace_eval_results = None
@@ -715,9 +709,6 @@ def _interaction_simulate(
     else:
         sharrow_enabled = state.settings.sharrow
     interaction_utilities = None
-
-    # if locals_d is not None and locals_d.get("_sharrow_skip", False):
-    #     sharrow_enabled = False
 
     if (
         sharrow_enabled

--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 
 from . import chunk, config, logit, simulate, tracing, workflow
-from .configuration.base import SharrowSettings
+from .configuration.base import ComputeSettings
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def eval_interaction_utilities(
     log_alt_losers=False,
     extra_data=None,
     zone_layer=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Compute the utilities for a single-alternative spec evaluated in the context of df
@@ -84,9 +84,9 @@ def eval_interaction_utilities(
     logger.info("Running eval_interaction_utilities on %s rows" % df.shape[0])
 
     sharrow_enabled = state.settings.sharrow
-    if sharrow_settings is None:
-        sharrow_settings = SharrowSettings()
-    if sharrow_settings.skip:
+    if compute_settings is None:
+        compute_settings = ComputeSettings()
+    if compute_settings.sharrow_skip:
         sharrow_enabled = False
 
     # if locals_d is not None and locals_d.get("_sharrow_skip", False):
@@ -190,7 +190,7 @@ def eval_interaction_utilities(
                 trace_label,
                 interacts=extra_data,
                 zone_layer=zone_layer,
-                sharrow_settings=sharrow_settings,
+                compute_settings=compute_settings,
             )
             if sh_util is not None:
                 chunk_sizer.log_df(trace_label, "sh_util", sh_util)
@@ -268,7 +268,7 @@ def eval_interaction_utilities(
                 exprs = spec.index
                 labels = spec.index
 
-            with sharrow_settings.pandas_option_context():
+            with compute_settings.pandas_option_context():
                 for expr, label, coefficient in zip(exprs, labels, spec.iloc[:, 0]):
                     try:
                         # - allow temps of form _od_DIST@od_skim['DIST']
@@ -620,7 +620,7 @@ def _interaction_simulate(
     log_alt_losers=False,
     estimator=None,
     chunk_sizer=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a MNL simulation in the situation in which alternatives must
@@ -708,7 +708,9 @@ def _interaction_simulate(
     alt_index_id = estimator.get_alt_id() if estimator else None
     chooser_index_id = ALT_CHOOSER_ID if log_alt_losers else None
 
-    if sharrow_settings is not None and sharrow_settings.skip:
+    if compute_settings is None:
+        compute_settings = ComputeSettings()
+    if compute_settings.sharrow_skip:
         sharrow_enabled = False
     else:
         sharrow_enabled = state.settings.sharrow
@@ -739,7 +741,7 @@ def _interaction_simulate(
             estimator=estimator,
             log_alt_losers=log_alt_losers,
             extra_data=alternatives,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         # set this index here as this is how later code extracts the chosen alt id's
@@ -804,7 +806,7 @@ def _interaction_simulate(
             trace_rows,
             estimator=estimator,
             log_alt_losers=log_alt_losers,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
         chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
         # mem.trace_memory_info(f"{trace_label}.init interaction_utilities", force_garbage_collect=True)
@@ -912,7 +914,7 @@ def interaction_simulate(
     trace_choice_name=None,
     estimator=None,
     explicit_chunk_size=0,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a simulation in the situation in which alternatives must
@@ -990,7 +992,7 @@ def interaction_simulate(
             log_alt_losers=log_alt_losers,
             estimator=estimator,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         result_list.append(choices)

--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -32,6 +32,7 @@ def eval_interaction_utilities(
     log_alt_losers=False,
     extra_data=None,
     zone_layer=None,
+    fastmath=True,
 ):
     """
     Compute the utilities for a single-alternative spec evaluated in the context of df
@@ -184,6 +185,7 @@ def eval_interaction_utilities(
                 trace_label,
                 interacts=extra_data,
                 zone_layer=zone_layer,
+                fastmath=fastmath,
             )
             if sh_util is not None:
                 chunk_sizer.log_df(trace_label, "sh_util", sh_util)
@@ -607,6 +609,7 @@ def _interaction_simulate(
     log_alt_losers=False,
     estimator=None,
     chunk_sizer=None,
+    fastmath: bool = True,
 ):
     """
     Run a MNL simulation in the situation in which alternatives must
@@ -722,6 +725,7 @@ def _interaction_simulate(
             estimator=estimator,
             log_alt_losers=log_alt_losers,
             extra_data=alternatives,
+            fastmath=fastmath,
         )
 
         # set this index here as this is how later code extracts the chosen alt id's
@@ -786,6 +790,7 @@ def _interaction_simulate(
             trace_rows,
             estimator=estimator,
             log_alt_losers=log_alt_losers,
+            fastmath=fastmath,
         )
         chunk_sizer.log_df(trace_label, "interaction_utilities", interaction_utilities)
         # mem.trace_memory_info(f"{trace_label}.init interaction_utilities", force_garbage_collect=True)
@@ -893,6 +898,7 @@ def interaction_simulate(
     trace_choice_name=None,
     estimator=None,
     explicit_chunk_size=0,
+    fastmath: bool = True,
 ):
     """
     Run a simulation in the situation in which alternatives must
@@ -970,6 +976,7 @@ def interaction_simulate(
             log_alt_losers=log_alt_losers,
             estimator=estimator,
             chunk_sizer=chunk_sizer,
+            fastmath=fastmath,
         )
 
         result_list.append(choices)

--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -566,6 +566,7 @@ def eval_interaction_utilities(
                     retrace_eval_parts_ = pd.concat(retrace_eval_parts, axis=1)
 
                     re_sh_flow_load = sh_flow.load(
+                        sh_tree,
                         dtype=np.float32,
                     )
                     re_sh_flow_load_ = re_sh_flow_load[re_trace]

--- a/activitysim/core/pathbuilder.py
+++ b/activitysim/core/pathbuilder.py
@@ -20,7 +20,7 @@ from activitysim.core import (
     tracing,
     workflow,
 )
-from activitysim.core.configuration.base import SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings
 from activitysim.core.pathbuilder_cache import memo
 from activitysim.core.util import reindex
 
@@ -89,7 +89,7 @@ def compute_utilities(
             trace_label=trace_label,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=SharrowSettings(skip=True),
+            compute_settings=ComputeSettings(sharrow_skip=True),
         )
 
     return utilities

--- a/activitysim/core/pathbuilder.py
+++ b/activitysim/core/pathbuilder.py
@@ -20,6 +20,7 @@ from activitysim.core import (
     tracing,
     workflow,
 )
+from activitysim.core.configuration.base import SharrowSettings
 from activitysim.core.pathbuilder_cache import memo
 from activitysim.core.util import reindex
 
@@ -56,7 +57,7 @@ def compute_utilities(
             f"{trace_label} Running compute_utilities with {choosers.shape[0]} choosers"
         )
 
-        locals_dict = {"np": np, "los": network_los, "disable_sharrow": True}
+        locals_dict = {"np": np, "los": network_los}
         locals_dict.update(model_constants)
 
         # we don't grok coefficients, but allow them to use constants in spec alt columns
@@ -88,6 +89,7 @@ def compute_utilities(
             trace_label=trace_label,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
+            sharrow_settings=SharrowSettings(skip=True),
         )
 
     return utilities

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -25,7 +25,7 @@ from activitysim.core import (
     util,
     workflow,
 )
-from activitysim.core.configuration.base import PydanticBase
+from activitysim.core.configuration.base import PydanticBase, SharrowSettings
 from activitysim.core.configuration.logit import (
     BaseLogitComponentSettings,
     LogitNestSpec,
@@ -57,7 +57,7 @@ def random_rows(state: workflow.State, df, n):
         return df
 
 
-def uniquify_spec_index(spec):
+def uniquify_spec_index(spec: pd.DataFrame):
     # uniquify spec index inplace
     # ensure uniqueness of spec index by appending comment with dupe count
     # this allows us to use pandas dot to compute_utilities
@@ -532,7 +532,7 @@ def eval_utilities(
     spec_sh=None,
     *,
     chunk_sizer,
-    fastmath=True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Evaluate a utility function as defined in a spec file.
@@ -613,7 +613,7 @@ def eval_utilities(
             trace_label,
             sharrow_enabled == "require",
             zone_layer=zone_layer,
-            fastmath=fastmath,
+            sharrow_settings=sharrow_settings,
         )
         utilities = sh_util
         timelogger.mark("sharrow flow", True, logger, trace_label)
@@ -1161,7 +1161,7 @@ def eval_mnl(
     trace_column_names=None,
     *,
     chunk_sizer,
-    fastmath=True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run a simulation for when the model spec does not involve alternative
@@ -1225,7 +1225,7 @@ def eval_mnl(
         estimator=estimator,
         trace_column_names=trace_column_names,
         chunk_sizer=chunk_sizer,
-        fastmath=fastmath,
+        sharrow_settings=sharrow_settings,
     )
     chunk_sizer.log_df(trace_label, "utilities", utilities)
 
@@ -1284,7 +1284,7 @@ def eval_nl(
     trace_column_names=None,
     *,
     chunk_sizer: chunk.ChunkSizer,
-    fastmath: bool = True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run a nested-logit simulation for when the model spec does not involve alternative
@@ -1348,7 +1348,7 @@ def eval_nl(
         trace_column_names=trace_column_names,
         spec_sh=spec_sh,
         chunk_sizer=chunk_sizer,
-        fastmath=fastmath,
+        sharrow_settings=sharrow_settings,
     )
     chunk_sizer.log_df(trace_label, "raw_utilities", raw_utilities)
 
@@ -1475,7 +1475,7 @@ def _simple_simulate(
     trace_column_names=None,
     *,
     chunk_sizer,
-    fastmath=True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run an MNL or NL simulation for when the model spec does not involve alternative
@@ -1539,7 +1539,7 @@ def _simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
-            fastmath=fastmath,
+            sharrow_settings=sharrow_settings,
         )
     else:
         choices = eval_nl(
@@ -1556,7 +1556,7 @@ def _simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
-            fastmath=fastmath,
+            sharrow_settings=sharrow_settings,
         )
 
     return choices
@@ -1595,7 +1595,7 @@ def simple_simulate(
     trace_label=None,
     trace_choice_name=None,
     trace_column_names=None,
-    fastmath: bool = True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     Run an MNL or NL simulation for when the model spec does not involve alternative
@@ -1630,7 +1630,7 @@ def simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
-            fastmath=fastmath,
+            sharrow_settings=sharrow_settings,
         )
 
         result_list.append(choices)
@@ -1658,7 +1658,7 @@ def simple_simulate_by_chunk_id(
     estimator=None,
     trace_label=None,
     trace_choice_name=None,
-    fastmath: bool = True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     chunk_by_chunk_id wrapper for simple_simulate
@@ -1685,7 +1685,7 @@ def simple_simulate_by_chunk_id(
             trace_label=chunk_trace_label,
             trace_choice_name=trace_choice_name,
             chunk_sizer=chunk_sizer,
-            fastmath=fastmath,
+            sharrow_settings=sharrow_settings,
         )
 
         result_list.append(choices)
@@ -1706,7 +1706,7 @@ def eval_mnl_logsums(
     trace_label=None,
     *,
     chunk_sizer,
-    fastmath: bool = True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     like eval_nl except return logsums instead of making choices
@@ -1736,7 +1736,7 @@ def eval_mnl_logsums(
         trace_label,
         have_trace_targets,
         chunk_sizer=chunk_sizer,
-        fastmath=fastmath,
+        sharrow_settings=sharrow_settings,
     )
     chunk_sizer.log_df(trace_label, "utilities", utilities)
 
@@ -1850,7 +1850,7 @@ def eval_nl_logsums(
     trace_label=None,
     *,
     chunk_sizer: chunk.ChunkSizer,
-    fastmath: bool = True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     like eval_nl except return logsums instead of making choices
@@ -1881,7 +1881,7 @@ def eval_nl_logsums(
         have_trace_targets=have_trace_targets,
         spec_sh=spec_sh,
         chunk_sizer=chunk_sizer,
-        fastmath=fastmath,
+        sharrow_settings=sharrow_settings,
     )
     chunk_sizer.log_df(trace_label, "raw_utilities", raw_utilities)
 
@@ -1932,7 +1932,7 @@ def _simple_simulate_logsums(
     trace_label=None,
     *,
     chunk_sizer,
-    fastmath: bool = True,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     like simple_simulate except return logsums instead of making choices
@@ -1954,7 +1954,7 @@ def _simple_simulate_logsums(
             locals_d,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
-            fastmath=fastmath,
+            sharrow_settings=sharrow_settings,
         )
     else:
         logsums = eval_nl_logsums(
@@ -1965,7 +1965,7 @@ def _simple_simulate_logsums(
             locals_d,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
-            fastmath=fastmath,
+            sharrow_settings=sharrow_settings,
         )
 
     return logsums
@@ -1982,6 +1982,7 @@ def simple_simulate_logsums(
     chunk_size=0,
     trace_label=None,
     chunk_tag=None,
+    sharrow_settings: SharrowSettings | None = None,
 ):
     """
     like simple_simulate except return logsums instead of making choices
@@ -2014,6 +2015,7 @@ def simple_simulate_logsums(
             locals_d,
             chunk_trace_label,
             chunk_sizer=chunk_sizer,
+            sharrow_settings=sharrow_settings,
         )
 
         result_list.append(logsums)

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -532,6 +532,7 @@ def eval_utilities(
     spec_sh=None,
     *,
     chunk_sizer,
+    fastmath=True,
 ):
     """
     Evaluate a utility function as defined in a spec file.
@@ -571,6 +572,8 @@ def eval_utilities(
         This is meant to give the same result, but allows for some optimizations
         or preprocessing outside the sharrow framework (e.g. to run the Python
         based transit virtual path builder and cache relevant values).
+    fastmath : bool, default True
+        Use fastmath for sharrow compiled code.
 
     Returns
     -------
@@ -610,6 +613,7 @@ def eval_utilities(
             trace_label,
             sharrow_enabled == "require",
             zone_layer=zone_layer,
+            fastmath=fastmath,
         )
         utilities = sh_util
         timelogger.mark("sharrow flow", True, logger, trace_label)
@@ -1157,6 +1161,7 @@ def eval_mnl(
     trace_column_names=None,
     *,
     chunk_sizer,
+    fastmath=True,
 ):
     """
     Run a simulation for when the model spec does not involve alternative
@@ -1220,6 +1225,7 @@ def eval_mnl(
         estimator=estimator,
         trace_column_names=trace_column_names,
         chunk_sizer=chunk_sizer,
+        fastmath=fastmath,
     )
     chunk_sizer.log_df(trace_label, "utilities", utilities)
 
@@ -1278,6 +1284,7 @@ def eval_nl(
     trace_column_names=None,
     *,
     chunk_sizer: chunk.ChunkSizer,
+    fastmath: bool = True,
 ):
     """
     Run a nested-logit simulation for when the model spec does not involve alternative
@@ -1308,6 +1315,8 @@ def eval_nl(
         This is the column label to be used in trace file csv dump of choices
     trace_column_names: str or list of str
         chooser columns to include when tracing expression_values
+    fastmath : bool, default True
+        Use fastmath for sharrow compiled code.
 
     Returns
     -------
@@ -1339,6 +1348,7 @@ def eval_nl(
         trace_column_names=trace_column_names,
         spec_sh=spec_sh,
         chunk_sizer=chunk_sizer,
+        fastmath=fastmath,
     )
     chunk_sizer.log_df(trace_label, "raw_utilities", raw_utilities)
 
@@ -1465,6 +1475,7 @@ def _simple_simulate(
     trace_column_names=None,
     *,
     chunk_sizer,
+    fastmath=True,
 ):
     """
     Run an MNL or NL simulation for when the model spec does not involve alternative
@@ -1528,6 +1539,7 @@ def _simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
+            fastmath=fastmath,
         )
     else:
         choices = eval_nl(
@@ -1544,6 +1556,7 @@ def _simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
+            fastmath=fastmath,
         )
 
     return choices
@@ -1582,6 +1595,7 @@ def simple_simulate(
     trace_label=None,
     trace_choice_name=None,
     trace_column_names=None,
+    fastmath: bool = True,
 ):
     """
     Run an MNL or NL simulation for when the model spec does not involve alternative
@@ -1616,6 +1630,7 @@ def simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
+            fastmath=fastmath,
         )
 
         result_list.append(choices)
@@ -1643,6 +1658,7 @@ def simple_simulate_by_chunk_id(
     estimator=None,
     trace_label=None,
     trace_choice_name=None,
+    fastmath: bool = True,
 ):
     """
     chunk_by_chunk_id wrapper for simple_simulate
@@ -1669,6 +1685,7 @@ def simple_simulate_by_chunk_id(
             trace_label=chunk_trace_label,
             trace_choice_name=trace_choice_name,
             chunk_sizer=chunk_sizer,
+            fastmath=fastmath,
         )
 
         result_list.append(choices)
@@ -1682,7 +1699,14 @@ def simple_simulate_by_chunk_id(
 
 
 def eval_mnl_logsums(
-    state: workflow.State, choosers, spec, locals_d, trace_label=None, *, chunk_sizer
+    state: workflow.State,
+    choosers,
+    spec,
+    locals_d,
+    trace_label=None,
+    *,
+    chunk_sizer,
+    fastmath: bool = True,
 ):
     """
     like eval_nl except return logsums instead of making choices
@@ -1712,6 +1736,7 @@ def eval_mnl_logsums(
         trace_label,
         have_trace_targets,
         chunk_sizer=chunk_sizer,
+        fastmath=fastmath,
     )
     chunk_sizer.log_df(trace_label, "utilities", utilities)
 
@@ -1825,6 +1850,7 @@ def eval_nl_logsums(
     trace_label=None,
     *,
     chunk_sizer: chunk.ChunkSizer,
+    fastmath: bool = True,
 ):
     """
     like eval_nl except return logsums instead of making choices
@@ -1855,6 +1881,7 @@ def eval_nl_logsums(
         have_trace_targets=have_trace_targets,
         spec_sh=spec_sh,
         chunk_sizer=chunk_sizer,
+        fastmath=fastmath,
     )
     chunk_sizer.log_df(trace_label, "raw_utilities", raw_utilities)
 
@@ -1905,6 +1932,7 @@ def _simple_simulate_logsums(
     trace_label=None,
     *,
     chunk_sizer,
+    fastmath: bool = True,
 ):
     """
     like simple_simulate except return logsums instead of making choices
@@ -1926,6 +1954,7 @@ def _simple_simulate_logsums(
             locals_d,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
+            fastmath=fastmath,
         )
     else:
         logsums = eval_nl_logsums(
@@ -1936,6 +1965,7 @@ def _simple_simulate_logsums(
             locals_d,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
+            fastmath=fastmath,
         )
 
     return logsums

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -572,8 +572,8 @@ def eval_utilities(
         This is meant to give the same result, but allows for some optimizations
         or preprocessing outside the sharrow framework (e.g. to run the Python
         based transit virtual path builder and cache relevant values).
-    fastmath : bool, default True
-        Use fastmath for sharrow compiled code.
+    sharrow_settings : SharrowSettings, optional
+        Settings for sharrow. If not given, the default settings are used.
 
     Returns
     -------
@@ -595,7 +595,7 @@ def eval_utilities(
     if spec_sh is None:
         spec_sh = spec
 
-    if locals_d is not None and "disable_sharrow" in locals_d:
+    if sharrow_settings is not None and sharrow_settings.skip:
         sharrow_enabled = False
 
     if sharrow_enabled:

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -25,7 +25,7 @@ from activitysim.core import (
     util,
     workflow,
 )
-from activitysim.core.configuration.base import PydanticBase, SharrowSettings
+from activitysim.core.configuration.base import ComputeSettings, PydanticBase
 from activitysim.core.configuration.logit import (
     BaseLogitComponentSettings,
     LogitNestSpec,
@@ -532,7 +532,7 @@ def eval_utilities(
     spec_sh=None,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Evaluate a utility function as defined in a spec file.
@@ -572,7 +572,7 @@ def eval_utilities(
         This is meant to give the same result, but allows for some optimizations
         or preprocessing outside the sharrow framework (e.g. to run the Python
         based transit virtual path builder and cache relevant values).
-    sharrow_settings : SharrowSettings, optional
+    compute_settings : ComputeSettings, optional
         Settings for sharrow. If not given, the default settings are used.
 
     Returns
@@ -595,9 +595,9 @@ def eval_utilities(
     if spec_sh is None:
         spec_sh = spec
 
-    if sharrow_settings is None:
-        sharrow_settings = SharrowSettings()
-    if sharrow_settings.skip:
+    if compute_settings is None:
+        compute_settings = ComputeSettings()
+    if compute_settings.sharrow_skip:
         sharrow_enabled = False
 
     if sharrow_enabled:
@@ -615,7 +615,7 @@ def eval_utilities(
             trace_label,
             sharrow_enabled == "require",
             zone_layer=zone_layer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
         utilities = sh_util
         timelogger.mark("sharrow flow", True, logger, trace_label)
@@ -647,7 +647,7 @@ def eval_utilities(
         chunk_sizer.log_df(trace_label, "expression_values", expression_values)
 
         i = 0
-        with sharrow_settings.pandas_option_context():
+        with compute_settings.pandas_option_context():
             for expr, coefficients in zip(exprs, spec.values):
                 try:
                     with warnings.catch_warnings(record=True) as w:
@@ -1164,7 +1164,7 @@ def eval_mnl(
     trace_column_names=None,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a simulation for when the model spec does not involve alternative
@@ -1228,7 +1228,7 @@ def eval_mnl(
         estimator=estimator,
         trace_column_names=trace_column_names,
         chunk_sizer=chunk_sizer,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     chunk_sizer.log_df(trace_label, "utilities", utilities)
 
@@ -1287,7 +1287,7 @@ def eval_nl(
     trace_column_names=None,
     *,
     chunk_sizer: chunk.ChunkSizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run a nested-logit simulation for when the model spec does not involve alternative
@@ -1351,7 +1351,7 @@ def eval_nl(
         trace_column_names=trace_column_names,
         spec_sh=spec_sh,
         chunk_sizer=chunk_sizer,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     chunk_sizer.log_df(trace_label, "raw_utilities", raw_utilities)
 
@@ -1478,7 +1478,7 @@ def _simple_simulate(
     trace_column_names=None,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run an MNL or NL simulation for when the model spec does not involve alternative
@@ -1542,7 +1542,7 @@ def _simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
     else:
         choices = eval_nl(
@@ -1559,7 +1559,7 @@ def _simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
     return choices
@@ -1598,7 +1598,7 @@ def simple_simulate(
     trace_label=None,
     trace_choice_name=None,
     trace_column_names=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     Run an MNL or NL simulation for when the model spec does not involve alternative
@@ -1633,7 +1633,7 @@ def simple_simulate(
             trace_choice_name=trace_choice_name,
             trace_column_names=trace_column_names,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         result_list.append(choices)
@@ -1661,7 +1661,7 @@ def simple_simulate_by_chunk_id(
     estimator=None,
     trace_label=None,
     trace_choice_name=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     chunk_by_chunk_id wrapper for simple_simulate
@@ -1688,7 +1688,7 @@ def simple_simulate_by_chunk_id(
             trace_label=chunk_trace_label,
             trace_choice_name=trace_choice_name,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         result_list.append(choices)
@@ -1709,7 +1709,7 @@ def eval_mnl_logsums(
     trace_label=None,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     like eval_nl except return logsums instead of making choices
@@ -1739,7 +1739,7 @@ def eval_mnl_logsums(
         trace_label,
         have_trace_targets,
         chunk_sizer=chunk_sizer,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     chunk_sizer.log_df(trace_label, "utilities", utilities)
 
@@ -1853,7 +1853,7 @@ def eval_nl_logsums(
     trace_label=None,
     *,
     chunk_sizer: chunk.ChunkSizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     like eval_nl except return logsums instead of making choices
@@ -1884,7 +1884,7 @@ def eval_nl_logsums(
         have_trace_targets=have_trace_targets,
         spec_sh=spec_sh,
         chunk_sizer=chunk_sizer,
-        sharrow_settings=sharrow_settings,
+        compute_settings=compute_settings,
     )
     chunk_sizer.log_df(trace_label, "raw_utilities", raw_utilities)
 
@@ -1935,7 +1935,7 @@ def _simple_simulate_logsums(
     trace_label=None,
     *,
     chunk_sizer,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     like simple_simulate except return logsums instead of making choices
@@ -1957,7 +1957,7 @@ def _simple_simulate_logsums(
             locals_d,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
     else:
         logsums = eval_nl_logsums(
@@ -1968,7 +1968,7 @@ def _simple_simulate_logsums(
             locals_d,
             trace_label=trace_label,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
     return logsums
@@ -1985,7 +1985,7 @@ def simple_simulate_logsums(
     chunk_size=0,
     trace_label=None,
     chunk_tag=None,
-    sharrow_settings: SharrowSettings | None = None,
+    compute_settings: ComputeSettings | None = None,
 ):
     """
     like simple_simulate except return logsums instead of making choices
@@ -2018,7 +2018,7 @@ def simple_simulate_logsums(
             locals_d,
             chunk_trace_label,
             chunk_sizer=chunk_sizer,
-            sharrow_settings=sharrow_settings,
+            compute_settings=compute_settings,
         )
 
         result_list.append(logsums)

--- a/activitysim/examples/prototype_arc/configs/auto_ownership.yaml
+++ b/activitysim/examples/prototype_arc/configs/auto_ownership.yaml
@@ -17,8 +17,3 @@ NESTS:
 
 SPEC: auto_ownership.csv
 COEFFICIENTS: auto_ownership_coeffs.csv
-
-LOGSUM_CHOOSER_COLUMNS:
-  - num_drivers
-  - num_workers
-  

--- a/activitysim/examples/prototype_mtc_extended/configs/school_escorting.yaml
+++ b/activitysim/examples/prototype_mtc_extended/configs/school_escorting.yaml
@@ -1,7 +1,8 @@
 # Some data values in the spec file will refer to missing values stored
 # as NaN in the data.  This requires the `sharrow_fastmath` setting to
 # be set to `false` to avoid errors in the sharrow implementation.
-sharrow_fastmath: false
+sharrow_settings:
+  fastmath: false
 
 OUTBOUND_SPEC: school_escorting_outbound.csv
 OUTBOUND_COEFFICIENTS: school_escorting_coefficients_outbound.csv

--- a/activitysim/examples/prototype_mtc_extended/configs/school_escorting.yaml
+++ b/activitysim/examples/prototype_mtc_extended/configs/school_escorting.yaml
@@ -1,10 +1,7 @@
-# The school escort model as written in this prototype is not
-# compatible with sharrow, so "sharrow_skip" must be activated here.
-# Currently the spec file has a few lines that evaluate differently in
-# the sharrow implementation, resulting in failure that are flagged by
-# the `test` mode.  Once these are fixed (and string comparisons are
-# minimized for performance) this `sharrow_skip` setting can be removed.
-sharrow_skip: true
+# Some data values in the spec file will refer to missing values stored
+# as NaN in the data.  This requires the `sharrow_fastmath` setting to
+# be set to `false` to avoid errors in the sharrow implementation.
+sharrow_fastmath: false
 
 OUTBOUND_SPEC: school_escorting_outbound.csv
 OUTBOUND_COEFFICIENTS: school_escorting_coefficients_outbound.csv

--- a/activitysim/examples/prototype_mtc_extended/configs/school_escorting.yaml
+++ b/activitysim/examples/prototype_mtc_extended/configs/school_escorting.yaml
@@ -1,7 +1,7 @@
 # Some data values in the spec file will refer to missing values stored
 # as NaN in the data.  This requires the `sharrow_fastmath` setting to
 # be set to `false` to avoid errors in the sharrow implementation.
-sharrow_settings:
+compute_settings:
   fastmath: false
 
 OUTBOUND_SPEC: school_escorting_outbound.csv

--- a/activitysim/examples/prototype_mtc_extended/configs/vehicle_type_choice.yaml
+++ b/activitysim/examples/prototype_mtc_extended/configs/vehicle_type_choice.yaml
@@ -2,7 +2,7 @@
 
 SPEC: vehicle_type_choice_op4.csv
 COEFFICIENTS: vehicle_type_choice_op4_coefficients.csv
-ALTS: vehicle_type_choice_op4_alternatives.csv
+#ALTS: vehicle_type_choice_op4_alternatives.csv
 
 # SPEC: vehicle_type_choice_op2.csv
 # COEFFICIENTS: vehicle_type_choice_op2_coefficients.csv

--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -40,7 +40,7 @@ dependencies:
 - openmatrix = 0.3.*
 - orca = 1.8
 - pandas = 1.4.*
-- pandera >= 0.15
+- pandera >= 0.15, <0.18.1
 - platformdirs = 3.2.*
 - pre-commit
 - psutil = 5.9.*

--- a/conda-environments/github-actions-tests.yml
+++ b/conda-environments/github-actions-tests.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy = 1.23.5
 - openmatrix = 0.3.5.0
 - orca = 1.8
-- pandera >= 0.15
+- pandera >= 0.15, <0.18.1
 - pandas = 1.4.*
 - platformdirs = 3.2.*
 - psutil = 5.9.*

--- a/docs/dev-guide/using-sharrow.md
+++ b/docs/dev-guide/using-sharrow.md
@@ -213,8 +213,14 @@ as needed.
 
 For models with utility expressions that include a lot of string comparisons,
 (e.g. because they are built for the legacy `pandas.eval` interpreter and have not
-been updated) sharrow can be disabled by setting `sharrow_skip: true` in the
-component's configuration yaml file.
+been updated) sharrow can be disabled by setting
+
+```yaml
+sharrow_settings:
+  skip: true
+```
+
+in the component's configuration yaml file.
 
 ### Multiprocessing Performance
 

--- a/docs/dev-guide/using-sharrow.md
+++ b/docs/dev-guide/using-sharrow.md
@@ -216,8 +216,8 @@ For models with utility expressions that include a lot of string comparisons,
 been updated) sharrow can be disabled by setting
 
 ```yaml
-sharrow_settings:
-  skip: true
+compute_settings:
+  sharrow_skip: true
 ```
 
 in the component's configuration yaml file.


### PR DESCRIPTION
The reason why the school escort model was failing with sharrow relates to the `fastmath` setting.

Part of how sharrow accelerates code evaluation is by turning on the "[fastmath](https://numba.readthedocs.io/en/stable/user/performance-tips.html#fastmath)" compiler optimizations in Numba.  Using this setting has numerous effects, but two are salient here: 

1. It makes the code run faster 
2. It can cause elementary operations to give unexpected results where one or more operands is `NaN`, e.g. normally evaluating `x < 0` should result in `False` when `x` is `NaN` but with `fastmath` turned on the result might be `True` instead; the actual result of such an operation is not defined and might be hardware dependent.

We do not want to simply turn off `fastmath`, as the speed we get from (1) is desirable and the problems created by (2) don't actually occur in most models, as most data columns in our tables don't include missing values.  But the school escort model DOES include missing values (e.g. the age of the 3rd child in a household with less than 3 children).  

This PR introduces a `sharrow_fastmath` setting for all relevant components, with `True` as the default for nearly all Sharrow-compiled model components, but adds a mechanism to turn it off for individual components as needed.  The school escort model has the default for this setting changed to `False`.
