### PR TITLE
fix bug in interaction_simulate

### DIFF
--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -565,9 +565,7 @@ def eval_interaction_utilities(
                     retrace_eval_data_ = pd.concat(retrace_eval_data, axis=1)
                     retrace_eval_parts_ = pd.concat(retrace_eval_parts, axis=1)
 
-                    re_sh_flow_load = sh_flow.load(
-                        dtype=np.float32,
-                    )
+                    re_sh_flow_load = sh_flow.load(sh_tree, dtype=np.float32)
                     re_sh_flow_load_ = re_sh_flow_load[re_trace]
 
                     look_for_problems_here = np.where(


### PR DESCRIPTION
We recently fixed a problem where sharrow was holding on to data references, sometimes preventing memory from being freed.

This introduced a bug in the sharrow-test error handler of the interaction simulate code, where sharrow re-runs data if it does not match utility values with the original non-sharrow code.  This PR fixes the bug.