### PR TITLE
BayDAG Contribution #16: Parking Locations in Trip Matrices

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -206,7 +206,6 @@ jobs:
       matrix:
         region:
           - prototype_mtc
-          - prototype_arc
           - placeholder_psrc
           - prototype_marin
           - prototype_mtc_extended

--- a/activitysim/abm/models/parking_location_choice.py
+++ b/activitysim/abm/models/parking_location_choice.py
@@ -330,6 +330,10 @@ class ParkingLocationSettings(LogitComponentSettings, extra="forbid"):
 
     SEGMENTS: list[str] | None = None
 
+    AUTO_MODES: list[str]
+    """List of auto modes that use parking. AUTO_MODES are used in write_trip_matrices to make sure
+    parking locations are accurately represented in the output trip matrices."""
+
 
 @workflow.step
 def parking_location(

--- a/activitysim/abm/models/trip_matrices.py
+++ b/activitysim/abm/models/trip_matrices.py
@@ -255,12 +255,6 @@ def write_trip_matrices(
             state, aggregate_trips, zone_index, orig_index, dest_index, model_settings
         )
 
-        if "parking_location" in state.settings.models:
-            # Set trip origin and destination to be the actual location the person is and not where their vehicle is parked
-            trips_df["origin"] = trips_df["true_origin"]
-            trips_df["destination"] = trips_df["true_destination"]
-            del trips_df["true_origin"], trips_df["true_destination"]
-
         logger.info("aggregating trips three zone tap...")
         aggregate_trips = trips_df.groupby(["btap", "atap"], sort=False).sum(
             numeric_only=True
@@ -295,6 +289,18 @@ def write_trip_matrices(
             True,
         )
 
+    if "parking_location" in state.settings.models:
+        # Set trip origin and destination to be the actual location the person is and not where their vehicle is parked
+        trips_df["origin"] = trips_df["true_origin"]
+        trips_df["destination"] = trips_df["true_destination"]
+        del trips_df["true_origin"], trips_df["true_destination"]
+        if network_los.zone_system == los.TWO_ZONE or network_los.zone_system == los.THREE_ZONE:
+            trips_df["otaz"] = (
+                state.get_table("land_use").reindex(trips_df["origin"]).TAZ.tolist()
+            )
+            trips_df["dtaz"] = (
+                state.get_table("land_use").reindex(trips_df["destination"]).TAZ.tolist()
+            )
 
 def annotate_trips(
     state: workflow.State,

--- a/activitysim/abm/models/trip_matrices.py
+++ b/activitysim/abm/models/trip_matrices.py
@@ -13,6 +13,7 @@ import pandas as pd
 from activitysim.core import config, expressions, los, workflow
 from activitysim.core.configuration.base import PreprocessorSettings, PydanticReadable
 from activitysim.core.configuration.logit import LogitComponentSettings
+from activitysim.abm.models.parking_location_choice import ParkingLocationSettings
 
 logger = logging.getLogger(__name__)
 
@@ -93,16 +94,35 @@ def write_trip_matrices(
         state.add_table("trips", trips_df)
 
     if "parking_location" in state.settings.models:
-        parking_settings = state.filesystem.read_model_settings(
-            "parking_location_choice.yaml"
+        parking_settings = ParkingLocationSettings.read_settings_file(
+            state.filesystem,
+            "parking_location_choice.yaml",
         )
-        parking_taz_col_name = parking_settings["ALT_DEST_COL_NAME"]
+        parking_taz_col_name = parking_settings.ALT_DEST_COL_NAME
+        if ~(trips_df["trip_mode"].isin(parking_settings.AUTO_MODES)).any():
+            logger.warning(
+                f"Parking location choice model is enabled, but none of {parking_settings.AUTO_MODES} auto modes found in trips table."
+                "See AUTO_MODES setting in parking_location_choice.yaml."
+            )
+
         if parking_taz_col_name in trips_df:
-            # TODO make parking zone negative, not zero, if not used
+            trips_df["true_origin"] = trips_df["origin"]
+            trips_df["true_destination"] = trips_df["destination"]
+
+            # Get origin parking zone if vehicle not parked at origin
+            trips_df["origin_parking_zone"] = np.where(
+                (trips_df["tour_id"] == trips_df["tour_id"].shift(1))
+                & trips_df["trip_mode"].isin(parking_settings.AUTO_MODES),
+                trips_df[parking_taz_col_name].shift(1),
+                -1,
+            )
+
             trips_df.loc[trips_df[parking_taz_col_name] > 0, "destination"] = trips_df[
                 parking_taz_col_name
             ]
-        # Also need address the return trip
+            trips_df.loc[trips_df["origin_parking_zone"] > 0, "origin"] = trips_df[
+                "origin_parking_zone"
+            ]
 
     # write matrices by zone system type
     if network_los.zone_system == los.ONE_ZONE:  # taz trips written to taz matrices
@@ -234,6 +254,12 @@ def write_trip_matrices(
         write_matrices(
             state, aggregate_trips, zone_index, orig_index, dest_index, model_settings
         )
+
+        if "parking_location" in state.settings.models:
+            # Set trip origin and destination to be the actual location the person is and not where their vehicle is parked
+            trips_df["origin"] = trips_df["true_origin"]
+            trips_df["destination"] = trips_df["true_destination"]
+            del trips_df["true_origin"], trips_df["true_destination"]
 
         logger.info("aggregating trips three zone tap...")
         aggregate_trips = trips_df.groupby(["btap", "atap"], sort=False).sum(

--- a/activitysim/abm/models/trip_matrices.py
+++ b/activitysim/abm/models/trip_matrices.py
@@ -294,13 +294,19 @@ def write_trip_matrices(
         trips_df["origin"] = trips_df["true_origin"]
         trips_df["destination"] = trips_df["true_destination"]
         del trips_df["true_origin"], trips_df["true_destination"]
-        if network_los.zone_system == los.TWO_ZONE or network_los.zone_system == los.THREE_ZONE:
+        if (
+            network_los.zone_system == los.TWO_ZONE
+            or network_los.zone_system == los.THREE_ZONE
+        ):
             trips_df["otaz"] = (
                 state.get_table("land_use").reindex(trips_df["origin"]).TAZ.tolist()
             )
             trips_df["dtaz"] = (
-                state.get_table("land_use").reindex(trips_df["destination"]).TAZ.tolist()
+                state.get_table("land_use")
+                .reindex(trips_df["destination"])
+                .TAZ.tolist()
             )
+
 
 def annotate_trips(
     state: workflow.State,


### PR DESCRIPTION
The current version of the code would overwrite the trip origin and destination with the parking location zone in write_trip_matrices. This PR changes that to leave trip origins and destinations unchanged and just has trip tables read from parking location for trips originating at a parking location.

This is done by adjusted the origin TAZ for trips following those that ended at a parking destination other than the trip destination so that the origin of the next trip was the zone where the vehicle was parked in in order to make traffic assignment more accurate. (This prevents vehicles from teleporting from the parking location to the trip origin). However, you also need to check to see if the subsequent trip was also made by auto, resulting in non-auto trips that being at the previous trip's parking location, which will have a slight impact on transit assignment. This pull request thus also requires an AUTO_MODES setting and only adjust the origin TAZ if the trip is made by an auto mode. It should be noted that there will still be "teleporting vehicles" if a person uses a parking location other than their destination and then goes on an atwork subtour using a non-auto mode, but that is expected to be less common and have only a minor impact on model results.

There are also a couple of additional lines so that the origin and destination TAZs reported in final_trips always match the origin and destination MAZs.

Required for SANDAG ABM3 -- yes.

Linking to original PRs https://github.com/SANDAG/activitysim/pull/64 and  https://github.com/SANDAG/activitysim/pull/65. 
cc'ing original author @JoeJimFlood 