### PR TITLE
pin pandera

### DIFF
--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -40,7 +40,7 @@ dependencies:
 - openmatrix = 0.3.*
 - orca = 1.8
 - pandas = 1.4.*
-- pandera >= 0.15
+- pandera >= 0.15, <0.18.1
 - platformdirs = 3.2.*
 - pre-commit
 - psutil = 5.9.*

--- a/conda-environments/github-actions-tests.yml
+++ b/conda-environments/github-actions-tests.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy = 1.23.5
 - openmatrix = 0.3.5.0
 - orca = 1.8
-- pandera >= 0.15
+- pandera >= 0.15, <0.18.1
 - pandas = 1.4.*
 - platformdirs = 3.2.*
 - psutil = 5.9.*


### PR DESCRIPTION
Pin pandera to >= 0.15, <0.18.1

This extends the patch from #832 to the other environments we use for testing.
