### PR TITLE
Various minor fixes

### DIFF
--- a/activitysim/abm/models/joint_tour_frequency_composition.py
+++ b/activitysim/abm/models/joint_tour_frequency_composition.py
@@ -23,18 +23,9 @@ from activitysim.core.configuration.base import PreprocessorSettings
 from activitysim.core.configuration.logit import LogitComponentSettings
 from activitysim.core.interaction_simulate import interaction_simulate
 
+from .util.tour_frequency import JointTourFreqCompSettings
+
 logger = logging.getLogger(__name__)
-
-
-class JointTourFrequencyCompositionSettings(LogitComponentSettings, extra="forbid"):
-    """
-    Settings for the `joint_tour_frequency_composition` component.
-    """
-
-    preprocessor: PreprocessorSettings | None = None
-    """Setting for the preprocessor."""
-
-    ALTS_PREPROCESSOR: PreprocessorSettings | None = None
 
 
 @workflow.step
@@ -42,7 +33,7 @@ def joint_tour_frequency_composition(
     state: workflow.State,
     households_merged: pd.DataFrame,
     persons: pd.DataFrame,
-    model_settings: JointTourFrequencyCompositionSettings | None = None,
+    model_settings: JointTourFreqCompSettings | None = None,
     model_settings_file_name: str = "joint_tour_frequency_composition.yaml",
     trace_label: str = "joint_tour_frequency_composition",
 ) -> None:
@@ -50,7 +41,7 @@ def joint_tour_frequency_composition(
     This model predicts the frequency and composition of fully joint tours.
     """
     if model_settings is None:
-        model_settings = JointTourFrequencyCompositionSettings.read_settings_file(
+        model_settings = JointTourFreqCompSettings.read_settings_file(
             state.filesystem,
             model_settings_file_name,
         )

--- a/activitysim/abm/models/joint_tour_frequency_composition.py
+++ b/activitysim/abm/models/joint_tour_frequency_composition.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from activitysim.abm.models.util.overlap import hh_time_window_overlap
 from activitysim.abm.models.util.tour_frequency import (
+    JointTourFreqCompSettings,
     process_joint_tours_frequency_composition,
 )
 from activitysim.core import (
@@ -19,11 +20,7 @@ from activitysim.core import (
     tracing,
     workflow,
 )
-from activitysim.core.configuration.base import PreprocessorSettings
-from activitysim.core.configuration.logit import LogitComponentSettings
 from activitysim.core.interaction_simulate import interaction_simulate
-
-from .util.tour_frequency import JointTourFreqCompSettings
 
 logger = logging.getLogger(__name__)
 

--- a/activitysim/abm/models/parking_location_choice.py
+++ b/activitysim/abm/models/parking_location_choice.py
@@ -179,7 +179,8 @@ def choose_parking_location(
     alt_dest_col_name = model_settings.ALT_DEST_COL_NAME
 
     # remove trips and alts columns that are not used in spec
-    locals_dict = config.get_model_constants(model_settings).copy()
+    locals_dict = state.get_global_constants()
+    locals_dict.update(config.get_model_constants(model_settings))
     locals_dict.update(skims)
     locals_dict["timeframe"] = "trip"
     locals_dict["PARKING"] = skims["op_skims"].dest_key

--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -181,7 +181,8 @@ def _destination_sample(
         )
         sample_size = 0
 
-    locals_dict = model_settings.CONSTANTS.copy()
+    locals_dict = state.get_global_constants().copy()
+    locals_dict.update(model_settings.CONSTANTS)
 
     # size_terms of destination zones are purpose-specific, and trips have various purposes
     # so the relevant size_term for each interaction_sample row

--- a/activitysim/abm/models/util/tour_frequency.py
+++ b/activitysim/abm/models/util/tour_frequency.py
@@ -628,13 +628,13 @@ def process_tours_frequency_composition(
 
 
 class JointTourFreqCompContent(PydanticReadable):
-    VALUE_MAP: dict[int, str]
-    COLUMNS: list[str]
+    VALUE_MAP: dict[int, str] = {}
+    COLUMNS: list[str] = []
 
 
 class JointTourFreqCompAlts(PydanticReadable):
-    PURPOSE: JointTourFreqCompContent
-    COMPOSITION: JointTourFreqCompContent
+    PURPOSE: JointTourFreqCompContent = JointTourFreqCompContent()
+    COMPOSITION: JointTourFreqCompContent = JointTourFreqCompContent()
 
 
 class JointTourFreqCompSettings(LogitComponentSettings, extra="forbid"):
@@ -642,7 +642,7 @@ class JointTourFreqCompSettings(LogitComponentSettings, extra="forbid"):
     Settings for joint tour frequency and composition.
     """
 
-    ALTS_TABLE_STRUCTURE: JointTourFreqCompAlts
+    ALTS_TABLE_STRUCTURE: JointTourFreqCompAlts = JointTourFreqCompAlts()
     preprocessor: PreprocessorSettings | None = None
     ALTS_PREPROCESSOR: PreprocessorSettings | None = None
 

--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -12,9 +12,8 @@ from typing import Mapping
 import numpy as np
 import pandas as pd
 
-from . import chunk, config, logit, simulate, tracing, workflow
-from activitysim.core import util
-from .configuration.base import ComputeSettings
+from activitysim.core import chunk, logit, simulate, tracing, util, workflow
+from activitysim.core.configuration.base import ComputeSettings
 
 logger = logging.getLogger(__name__)
 
@@ -554,7 +553,7 @@ def eval_interaction_utilities(
                         if expr.startswith("@"):
                             v = to_series(eval(expr[1:], globals(), locals_d))
                         else:
-                            v = df.eval(expr)
+                            v = df.eval(expr, resolvers=[locals_d])
                         if check_for_variability and v.std() == 0:
                             logger.info(
                                 "%s: no variability (%s) in: %s"

--- a/conda-environments/docbuild.yml
+++ b/conda-environments/docbuild.yml
@@ -33,6 +33,7 @@ dependencies:
 - openmatrix >= 0.3.4.1
 - orca >= 1.6
 - pandas >= 1.1.0,<2
+- pandera >= 0.15, <0.18.1
 - platformdirs
 - psutil >= 4.1
 - pyarrow >= 2.0


### PR DESCRIPTION
- **Remove duplicate JointTourFrequencyCompositionSettings**. Previous work accidentally created two slightly different versions of `JointTourFrequencyCompositionSettings`.  This PR removes one of the two and just uses one version in all places where it is expected.
- **Add global constants to some models** from which they were missing: parking location and trip destination.
- **Include constants in sharrow tracing** and test recovery (when sharrow and legacy code results don't match)