### PR TITLE
Allow skim access in trip mode choice annotate

### DIFF
--- a/activitysim/abm/models/trip_mode_choice.py
+++ b/activitysim/abm/models/trip_mode_choice.py
@@ -371,6 +371,12 @@ def trip_mode_choice(
     state.add_table("trips", trips_df)
 
     if model_settings.annotate_trips:
+        # need to update locals_dict to access skims that are the same .shape as trips table
+        locals_dict = {}
+        locals_dict.update(constants)
+        simulate.set_skim_wrapper_targets(trips_merged, skims)
+        locals_dict.update(skims)
+        locals_dict["timeframe"] = "trip"
         annotate.annotate_trips(state, model_settings, trace_label, locals_dict)
 
     if state.settings.trace_hh_id:


### PR DESCRIPTION
This PR allows for the annotation step in trip mode choice to access skims.  The use case for this is in reporting where network LOS can be appended directly to the trips table at the end of trip mode choice. 

Analogous commit in BayDAG repo [here](https://github.com/SANDAG/activitysim/commit/777503395d1804f5864f1d52bac8851097985c97)

cc original author: @aber-sandag