### PR TITLE
Alts Attributes

### DIFF
--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -205,7 +205,6 @@ def _destination_sample(
             "size_terms_array": size_term_matrix.df.to_numpy(),
             "timeframe": "trip",
             "land_use": state.get_dataframe("land_use"),
-            "land_use_taz": state.get_dataframe("land_use_taz"),
         }
     )
     locals_dict.update(skims)


### PR DESCRIPTION
In #774, we added the ability to use the "reindex" function in location choice models, essentially allowing a user to merge in data from the land_use table into the chooser table from inside a utility spec.  This is problematic for sharrow.

This PR takes a different approach: typically the alternatives table in the sampling step as an index-only dataframe, but it doesn't *need* to be.  Here we add a config setting on the trip destination component to allow users to name columns that should be merged onto the alternatives before they are broadcast against the choosers.  This is more efficient and works with sharrow.

This PR pairs with https://github.com/ActivitySim/sandag-abm3-example/pull/11, which implements it on the SANDAG demo model.