### PR TITLE
ensure tour_type is categorical

### DIFF
--- a/activitysim/abm/models/util/tour_frequency.py
+++ b/activitysim/abm/models/util/tour_frequency.py
@@ -791,5 +791,6 @@ def create_joint_tours(
     tours["tour_type_num"] = tours["tour_type_num"].astype("int8")
     tours["tour_type_count"] = tours["tour_type_count"].astype("int8")
     tours["number_of_participants"] = tours["number_of_participants"].astype("int8")
+    tours["tour_type"] = tours["tour_type"].astype("category")
 
     return tours


### PR DESCRIPTION
We missed one spot to make sure that `tour_type` remains categorical.  Failure to do so has potentially severe negative implications for sharrow performance.