### PR TITLE
`protect_columns` for all simulations (choosers, alts, simple simulate, interaction simulate, etc)

### DIFF
--- a/activitysim/abm/models/parking_location_choice.py
+++ b/activitysim/abm/models/parking_location_choice.py
@@ -186,9 +186,19 @@ def choose_parking_location(
     locals_dict["PARKING"] = skims["op_skims"].dest_key
 
     spec = get_spec_for_segment(state, model_settings, segment_name)
-    trips = drop_unused_columns(trips, spec, locals_dict, custom_chooser=None)
+    trips = drop_unused_columns(
+        trips,
+        spec,
+        locals_dict,
+        custom_chooser=None,
+        additional_columns=model_settings.compute_settings.protect_columns,
+    )
     alternatives = drop_unused_columns(
-        alternatives, spec, locals_dict, custom_chooser=None
+        alternatives,
+        spec,
+        locals_dict,
+        custom_chooser=None,
+        additional_columns=model_settings.compute_settings.protect_columns,
     )
 
     destination_sample = logit.interaction_dataset(

--- a/activitysim/abm/models/trip_scheduling_choice.py
+++ b/activitysim/abm/models/trip_scheduling_choice.py
@@ -13,7 +13,11 @@ from activitysim.abm.models.util.trip import (
     get_time_windows,
 )
 from activitysim.core import chunk, expressions, simulate, tracing, workflow
-from activitysim.core.configuration.base import PreprocessorSettings, PydanticReadable
+from activitysim.core.configuration.base import (
+    ComputeSettings,
+    PreprocessorSettings,
+    PydanticReadable,
+)
 from activitysim.core.interaction_sample_simulate import _interaction_sample_simulate
 from activitysim.core.skim_dataset import SkimDataset
 from activitysim.core.skim_dictionary import SkimDict
@@ -223,6 +227,7 @@ def run_trip_scheduling_choice(
     skims,
     locals_dict: Mapping,
     trace_label: str,
+    model_settings: TripSchedulingChoiceSettings,
 ):
     NUM_TOUR_LEGS = 3
     trace_label = tracing.extend_trace_label(trace_label, "interaction_sample_simulate")
@@ -296,6 +301,7 @@ def run_trip_scheduling_choice(
                 trace_choice_name="trip_schedule_stage_1",
                 estimator=None,
                 chunk_sizer=chunk_sizer,
+                compute_settings=model_settings.compute_settings,
             )
 
             assert len(choices.index) == len(choosers.index)
@@ -337,6 +343,9 @@ class TripSchedulingChoiceSettings(PydanticReadable, extra="forbid"):
 
     SPECIFICATION: str
     """file name of specification file"""
+
+    compute_settings: ComputeSettings = ComputeSettings()
+    """Compute settings for this component."""
 
 
 @workflow.step
@@ -419,7 +428,13 @@ def trip_scheduling_choice(
         )
 
     tours_df = run_trip_scheduling_choice(
-        state, spec, tours_df, skims, locals_dict, trace_label
+        state,
+        spec,
+        tours_df,
+        skims,
+        locals_dict,
+        trace_label,
+        model_settings,
     )
 
     state.add_table("tours", tours_df)

--- a/activitysim/core/configuration/base.py
+++ b/activitysim/core/configuration/base.py
@@ -243,6 +243,7 @@ class ComputeSettings(PydanticBase):
             use_numexpr=self.use_numexpr,
             use_numba=self.use_numba,
             drop_unused_columns=self.drop_unused_columns,
+            protect_columns=self.protect_columns,
         )
 
 

--- a/activitysim/core/interaction_sample.py
+++ b/activitysim/core/interaction_sample.py
@@ -257,6 +257,7 @@ def _interaction_sample(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=sharrow_enabled,
+            additional_columns=compute_settings.protect_columns,
         )
 
         alternatives = util.drop_unused_columns(
@@ -265,7 +266,7 @@ def _interaction_sample(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=sharrow_enabled,
-            additional_columns=["tdd", "origin_destination"],
+            additional_columns=compute_settings.protect_columns,
         )
 
     if sharrow_enabled:

--- a/activitysim/core/interaction_sample.py
+++ b/activitysim/core/interaction_sample.py
@@ -266,7 +266,7 @@ def _interaction_sample(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=sharrow_enabled,
-            additional_columns=compute_settings.protect_columns,
+            additional_columns=["tdd"] + compute_settings.protect_columns,
         )
 
     if sharrow_enabled:

--- a/activitysim/core/interaction_sample_simulate.py
+++ b/activitysim/core/interaction_sample_simulate.py
@@ -158,6 +158,7 @@ def _interaction_sample_simulate(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=sharrow_enabled,
+            additional_columns=compute_settings.protect_columns,
         )
 
         alternatives = util.drop_unused_columns(
@@ -166,7 +167,7 @@ def _interaction_sample_simulate(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=sharrow_enabled,
-            additional_columns=["tdd", "origin_destination"],
+            additional_columns=compute_settings.protect_columns,
         )
 
     interaction_df = alternatives.join(choosers, how="left", rsuffix="_chooser")

--- a/activitysim/core/interaction_sample_simulate.py
+++ b/activitysim/core/interaction_sample_simulate.py
@@ -167,7 +167,7 @@ def _interaction_sample_simulate(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=sharrow_enabled,
-            additional_columns=compute_settings.protect_columns,
+            additional_columns=["tdd"] + compute_settings.protect_columns,
         )
 
     interaction_df = alternatives.join(choosers, how="left", rsuffix="_chooser")

--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -729,6 +729,7 @@ def _interaction_simulate(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=sharrow_enabled,
+            additional_columns=compute_settings.protect_columns,
         )
 
     if (

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -1989,6 +1989,7 @@ def _simple_simulate_logsums(
             locals_d,
             custom_chooser=None,
             sharrow_enabled=state.settings.sharrow,
+            additional_columns=compute_settings.protect_columns,
         )
 
     if nest_spec is None:

--- a/activitysim/examples/prototype_sandag_xborder/configs/tour_od_choice.yaml
+++ b/activitysim/examples/prototype_sandag_xborder/configs/tour_od_choice.yaml
@@ -55,3 +55,7 @@ SEGMENTS:
 
 LOGSUM_SETTINGS: tour_mode_choice
 LOGSUM_PREPROCESSOR: preprocessor
+
+compute_settings:
+  protect_columns:
+  - origin_destination


### PR DESCRIPTION
This PR includes the following fixes:	

- [x] Add `protect_columns` to all core simulate functions. `protect_columns` is a setting under `compute_settings` that can be used to protect specific columns from being dropped. But it was not fully implemented for all core simulate functions.
- [x] Protecting special columns in the ALT table from being dropped was done previously by hardcoding them in source code, like in simulate_sample.py: https://github.com/ActivitySim/activitysim/blob/1cb48c7acc2c377f4822e2521a19503842aaa495/activitysim/core/interaction_sample.py#L268 This is ok (and efficient) for `tdd` since it’s a generic variable, but less so for `origin_destination` since it’s a variable only relevant to the SANDAG xborder model. Furthermore, this crashes the ARC trip scheduling choice model. This PR moves the non-generic columns from source code to implementation-specific settings.
- [x] Set up `comupte_settings` in trip_scheduling_choice.py
- [x] Add `protect_columns` in parking_location_choice.py