### PR TITLE
Sharrow Cache Dir Setting

### DIFF
--- a/activitysim/core/configuration/filesystem.py
+++ b/activitysim/core/configuration/filesystem.py
@@ -134,6 +134,18 @@ class FileSystem(PydanticBase, validate_assignment=True):
 
         return self
 
+    def parse_settings(self, settings):
+        def _parse_setting(name, x):
+            v = getattr(settings, x, None)
+            if v is not None:
+                setattr(self, name, v)
+
+        _parse_setting("cache_dir", "cache_dir")
+        _parse_setting("sharrow_cache_dir", "sharrow_cache_dir")
+        _parse_setting("profile_dir", "profile_dir")
+        _parse_setting("pipeline_file_name", "pipeline_file_name")
+        return
+
     def get_working_subdir(self, subdir) -> Path:
         if self.working_dir:
             return self.working_dir.joinpath(subdir)

--- a/activitysim/core/mp_tasks.py
+++ b/activitysim/core/mp_tasks.py
@@ -887,6 +887,7 @@ def setup_injectables_and_logging(injectables, locutor: bool = True) -> workflow
     state = workflow.State()
     state = state.initialize_filesystem(**injectables)
     state.settings = injectables.get("settings", Settings())
+    state.filesystem.parse_settings(state.settings)
 
     # register abm steps and other abm-specific injectables
     # by default, assume we are running activitysim.abm

--- a/activitysim/core/workflow/state.py
+++ b/activitysim/core/workflow/state.py
@@ -478,14 +478,11 @@ class State:
             include_stack=False,
         )
 
-        # the settings can redefine the cache directories.
-        cache_dir = raw_settings.pop("cache_dir", None)
-        if cache_dir:
-            if self.filesystem.cache_dir != cache_dir:
-                logger.warning(f"settings file changes cache_dir to {cache_dir}")
-                self.filesystem.cache_dir = cache_dir
         settings_class = self.__class__.settings.member_type
         self.settings: Settings = settings_class.model_validate(raw_settings)
+
+        # need to parse any filesystem settings set in the settings file itself
+        self.filesystem.parse_settings(self.settings)
 
         extra_settings = set(self.settings.__dict__) - set(settings_class.__fields__)
 


### PR DESCRIPTION
Fix for #890. Also fixes the same issue for `profile_dir` and `pipeline_file_name` settings.