### PR TITLE
Skip nesting coefficient evaluation when evaluating logsums using MNL models

### DIFF
--- a/activitysim/abm/models/util/logsums.py
+++ b/activitysim/abm/models/util/logsums.py
@@ -167,8 +167,10 @@ def compute_location_choice_logsums(
     )
 
     nest_spec = config.get_logit_model_settings(logsum_settings)
-    if nest_spec is not None: # nest_spec is None for MNL
-        nest_spec = simulate.eval_nest_coefficients(nest_spec, coefficients, trace_label)
+    if nest_spec is not None:  # nest_spec is None for MNL
+        nest_spec = simulate.eval_nest_coefficients(
+            nest_spec, coefficients, trace_label
+        )
 
     locals_dict = {}
     # model_constants can appear in expressions

--- a/activitysim/abm/models/util/logsums.py
+++ b/activitysim/abm/models/util/logsums.py
@@ -167,7 +167,8 @@ def compute_location_choice_logsums(
     )
 
     nest_spec = config.get_logit_model_settings(logsum_settings)
-    nest_spec = simulate.eval_nest_coefficients(nest_spec, coefficients, trace_label)
+    if nest_spec is not None: # nest_spec is None for MNL
+        nest_spec = simulate.eval_nest_coefficients(nest_spec, coefficients, trace_label)
 
     locals_dict = {}
     # model_constants can appear in expressions


### PR DESCRIPTION
Addresses #908. This adds a line to skip the evaluation of the nesting coefficients if the nest_spec is `None`, which happens if the model is MNL.