### PR TITLE
update core tests

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -26,13 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-variant: Mambaforge
             miniforge-version: latest
             activate-environment: asim-test
-            use-mamba: true
             python-version: ${{ matrix.python-version }}
 
       - name: Set cache date for year and month
@@ -46,7 +44,7 @@ jobs:
 
       - name: Update environment
         run: |
-          mamba env update -n asim-test -f conda-environments/github-actions-tests.yml
+          conda env update -n asim-test -f conda-environments/github-actions-tests.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install activitysim
@@ -58,8 +56,8 @@ jobs:
 
       - name: Conda checkup
         run: |
-          mamba info -a
-          mamba list
+          conda info -a
+          conda list
 
       - name: Lint with Black
         run: |
@@ -111,13 +109,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-variant: Mambaforge
             miniforge-version: latest
             activate-environment: asim-test
-            use-mamba: true
             python-version: ${{ matrix.python-version }}
 
       - name: Set cache date for year and month
@@ -131,7 +127,7 @@ jobs:
 
       - name: Update environment
         run: |
-          mamba env update -n asim-test -f conda-environments/github-actions-tests.yml
+          conda env update -n asim-test -f conda-environments/github-actions-tests.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install activitysim
@@ -143,8 +139,8 @@ jobs:
 
       - name: Conda checkup
         run: |
-          mamba info -a
-          mamba list
+          conda info -a
+          conda list
 
       - name: Lint with Black
         run: |
@@ -194,13 +190,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: asim-test
-          use-mamba: true
           python-version: ${{ env.python-version }}
 
       - name: Set cache date for year and month
@@ -214,7 +208,7 @@ jobs:
 
       - name: Update environment
         run: |
-          mamba env update -n asim-test -f conda-environments/github-actions-tests.yml
+          conda env update -n asim-test -f conda-environments/github-actions-tests.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install activitysim
@@ -226,8 +220,8 @@ jobs:
 
       - name: Conda checkup
         run: |
-          mamba info -a
-          mamba list
+          conda info -a
+          conda list
 
       # TODO: Cache sharrow compiled flows?  The contents of __pycache__ appear to
       #       be ignored, so this is not working as expected right now
@@ -282,13 +276,11 @@ jobs:
       - name: Checkout ActivitySim
         uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: asim-test
-          use-mamba: true
           python-version: ${{ env.python-version }}
 
       - name: Set cache date for year and month
@@ -304,7 +296,7 @@ jobs:
 
       - name: Update environment
         run: |
-          mamba env update -n asim-test -f conda-environments/github-actions-tests.yml
+          conda env update -n asim-test -f conda-environments/github-actions-tests.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install activitysim
@@ -316,8 +308,8 @@ jobs:
 
       - name: Conda checkup
         run: |
-          mamba info -a
-          mamba list
+          conda info -a
+          conda list
 
       - name: Checkout Example
         uses: actions/checkout@v4
@@ -345,13 +337,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: asim-test
-          use-mamba: true
           python-version: ${{ env.python-version }}
 
       - name: Set cache date for year and month
@@ -365,7 +355,7 @@ jobs:
 
       - name: Update environment
         run: |
-          mamba env update -n asim-test -f conda-environments/github-actions-tests.yml
+          conda env update -n asim-test -f conda-environments/github-actions-tests.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install activitysim
@@ -377,8 +367,8 @@ jobs:
 
       - name: Conda checkup
         run: |
-          mamba info -a
-          mamba list
+          conda info -a
+          conda list
 
       - name: Test Random Seed Generation
         run: |
@@ -392,18 +382,16 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    name: estimation_mode_test
+    name: Estimation Mode Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: asim-test
-          use-mamba: true
           python-version: ${{ env.python-version }}
 
       - name: Set cache date for year and month
@@ -417,7 +405,7 @@ jobs:
 
       - name: Update environment
         run: |
-          mamba env update -n asim-test -f conda-environments/github-actions-tests.yml
+          conda env update -n asim-test -f conda-environments/github-actions-tests.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install Larch
@@ -432,8 +420,8 @@ jobs:
 
       - name: Conda checkup
         run: |
-          mamba info -a
-          mamba list
+          conda info -a
+          conda list
 
       - name: Test Estimation Mode
         run: |
@@ -458,9 +446,7 @@ jobs:
       - name: Install dependencies
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           environment-file: conda-environments/docbuild.yml
           python-version: "3.10"
           activate-environment: docbuild


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/core_tests.yml` file, primarily focusing on switching from Mambaforge to Miniforge and replacing `mamba` commands with `conda` commands.

Changes to setup:

* Replaced `Setup Mambaforge` with `Setup Miniforge` and removed the `miniforge-variant` and `use-mamba` options. [[1]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L29-L35) [[2]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L114-L120) [[3]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L197-L203) [[4]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L285-L291) [[5]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L348-L354) [[6]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L395-L406)

Changes to environment update:

* Replaced `mamba env update` with `conda env update` for updating the environment. [[1]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L49-R47) [[2]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L134-R130) [[3]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L217-R211) [[4]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L307-R299) [[5]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L368-R358) [[6]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L420-R408)

Changes to conda checkup:

* Replaced `mamba info` and `mamba list` with `conda info` and `conda list` for checking the conda environment. [[1]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L61-R60) [[2]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L146-R143) [[3]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L229-R224) [[4]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L319-R312) [[5]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L380-R371) [[6]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L435-R424)

Other changes:

* Updated the job name from `estimation_mode_test` to `Estimation Mode Unit Tests`.
* Removed the `miniforge-variant` and `use-mamba` options from the `Install dependencies` step.