### PR TITLE
GitHub Actions updates

### DIFF
--- a/.github/workflows/branch-docs.yml
+++ b/.github/workflows/branch-docs.yml
@@ -11,6 +11,8 @@ jobs:
     # develop branch docs are built at the end of the core test workflow, regardless of repository owner or commit message flags
     name: ubuntu-latest py3.10
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash -l {0}
@@ -60,7 +62,7 @@ jobs:
           make html
 
       - name: Push to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Token is created automatically by Github Actions, no other config needed

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
 
@@ -116,7 +116,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
 
@@ -199,7 +199,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -287,7 +287,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -350,7 +350,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -402,7 +402,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -444,6 +444,8 @@ jobs:
     if: github.ref_name == 'main'
     name: develop-docbuild
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash -l {0}
@@ -484,7 +486,7 @@ jobs:
           make clean
           make html
       - name: Push to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Token is created automatically by Github Actions, no other config needed

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  CACHE_NUMBER: 2  # increase to reset cache manually
+  CACHE_NUMBER: 0  # increase to reset cache manually
 
 jobs:
   foundation:
@@ -29,9 +29,11 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-version: latest
-            activate-environment: asim-test
-            python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          miniforge-version: latest
+          conda-solver: libmamba
+          activate-environment: asim-test
+          python-version: ${{ matrix.python-version }}
 
       - name: Set cache date for year and month
         run: echo "DATE=$(date +'%Y%m')" >> $GITHUB_ENV
@@ -112,9 +114,11 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-version: latest
-            activate-environment: asim-test
-            python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          miniforge-version: latest
+          conda-solver: libmamba
+          activate-environment: asim-test
+          python-version: ${{ matrix.python-version }}
 
       - name: Set cache date for year and month
         run: echo "DATE=$(date +'%Y%m')" >> $GITHUB_ENV
@@ -193,7 +197,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -279,7 +285,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -340,7 +348,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -390,7 +400,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for building documentation and running core tests. The changes involve updating permissions, modifying caching strategies, and upgrading dependencies.

### Workflow Updates:

* [`.github/workflows/branch-docs.yml`](diffhunk://#diff-cfbbfdfeb3df9cb70af98df05e62e67a31c64d53386e8fdeecbac4be9934d9f4R14-R15): Added `contents: write` permissions and upgraded `peaceiris/actions-gh-pages` to version 4. [[1]](diffhunk://#diff-cfbbfdfeb3df9cb70af98df05e62e67a31c64d53386e8fdeecbac4be9934d9f4R14-R15) [[2]](diffhunk://#diff-cfbbfdfeb3df9cb70af98df05e62e67a31c64d53386e8fdeecbac4be9934d9f4L63-R65)

* `.github/workflows/core_tests.yml`: 
  * Changed `CACHE_NUMBER` to `0` to reset the cache.
  * Enabled `auto-update-conda` and set `conda-solver` to `classic` in multiple jobs using `conda-incubator/setup-miniconda`. [[1]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R32-R34) [[2]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R117-R119) [[3]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R200-R202) [[4]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R288-R290) [[5]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R351-R353) [[6]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R403-R405)
  * Added `contents: write` permissions and upgraded `peaceiris/actions-gh-pages` to version 4. [[1]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R447-R448) [[2]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L475-R489)