### PR TITLE
release instructions

### DIFF
--- a/.github/workflows/branch-docs.yml
+++ b/.github/workflows/branch-docs.yml
@@ -11,6 +11,8 @@ jobs:
     # develop branch docs are built at the end of the core test workflow, regardless of repository owner or commit message flags
     name: ubuntu-latest py3.10
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash -l {0}
@@ -60,7 +62,7 @@ jobs:
           make html
 
       - name: Push to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Token is created automatically by Github Actions, no other config needed

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
 
@@ -116,7 +116,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
 
@@ -199,7 +199,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -287,7 +287,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -350,7 +350,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -402,7 +402,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          conda-solver: libmamba
+          conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - '*'
+  
+  workflow_dispatch:
 
 env:
   CACHE_NUMBER: 0  # increase to reset cache manually

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
+          mamba-version: "2.0.5"
           conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
@@ -118,6 +119,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
+          mamba-version: "2.0.5"
           conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
@@ -201,6 +203,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
+          mamba-version: "2.0.5"
           conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
@@ -289,6 +292,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
+          mamba-version: "2.0.5"
           conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
@@ -352,6 +356,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
+          mamba-version: "2.0.5"
           conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
@@ -404,6 +409,7 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
+          mamba-version: "2.0.5"
           conda-solver: classic
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
@@ -463,6 +469,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
+          mamba-version: "2.0.5"
           environment-file: conda-environments/docbuild.yml
           python-version: "3.10"
           activate-environment: docbuild

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -35,6 +35,7 @@ jobs:
           miniforge-version: latest
           mamba-version: "2.0.5"
           conda-solver: classic
+          conda-remove-defaults: true
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
 
@@ -121,6 +122,7 @@ jobs:
           miniforge-version: latest
           mamba-version: "2.0.5"
           conda-solver: classic
+          conda-remove-defaults: true
           activate-environment: asim-test
           python-version: ${{ matrix.python-version }}
 
@@ -205,6 +207,7 @@ jobs:
           miniforge-version: latest
           mamba-version: "2.0.5"
           conda-solver: classic
+          conda-remove-defaults: true
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -294,6 +297,7 @@ jobs:
           miniforge-version: latest
           mamba-version: "2.0.5"
           conda-solver: classic
+          conda-remove-defaults: true
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -358,6 +362,7 @@ jobs:
           miniforge-version: latest
           mamba-version: "2.0.5"
           conda-solver: classic
+          conda-remove-defaults: true
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -411,6 +416,7 @@ jobs:
           miniforge-version: latest
           mamba-version: "2.0.5"
           conda-solver: classic
+          conda-remove-defaults: true
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -470,6 +476,7 @@ jobs:
         with:
           miniforge-version: latest
           mamba-version: "2.0.5"
+          conda-remove-defaults: true
           environment-file: conda-environments/docbuild.yml
           python-version: "3.10"
           activate-environment: docbuild

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -444,6 +444,8 @@ jobs:
     if: github.ref_name == 'main'
     name: develop-docbuild
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash -l {0}
@@ -484,7 +486,7 @@ jobs:
           make clean
           make html
       - name: Push to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Token is created automatically by Github Actions, no other config needed

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  CACHE_NUMBER: 2  # increase to reset cache manually
+  CACHE_NUMBER: 0  # increase to reset cache manually
 
 jobs:
   foundation:
@@ -29,9 +29,11 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-version: latest
-            activate-environment: asim-test
-            python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          miniforge-version: latest
+          conda-solver: libmamba
+          activate-environment: asim-test
+          python-version: ${{ matrix.python-version }}
 
       - name: Set cache date for year and month
         run: echo "DATE=$(date +'%Y%m')" >> $GITHUB_ENV
@@ -112,9 +114,11 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-version: latest
-            activate-environment: asim-test
-            python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          miniforge-version: latest
+          conda-solver: libmamba
+          activate-environment: asim-test
+          python-version: ${{ matrix.python-version }}
 
       - name: Set cache date for year and month
         run: echo "DATE=$(date +'%Y%m')" >> $GITHUB_ENV
@@ -193,7 +197,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -279,7 +285,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -340,7 +348,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 
@@ -390,7 +400,9 @@ jobs:
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           miniforge-version: latest
+          conda-solver: libmamba
           activate-environment: asim-test
           python-version: ${{ env.python-version }}
 

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -112,6 +112,13 @@
     trigger various GitHub Actions scripts to build, test, and publish the
     new release to PyPI and conda forge, assuming there are no errors.
 
+00. Build the ActivitySim Standalone Windows Installer.  This is done using 
+    GitHub Actions, but it is not done automatically when a release is created, 
+    instead it requires a manual workflow dispatch trigger.  You can do this by 
+    going to the [build_installer workflow page](https://github.com/ActivitySim/activitysim/actions/workflows/build_installer.yml)
+    and clicking on the "Run workflow" button.  You will need to provide the 
+    version number and choose to add the built installer to the release.
+
 00. Clean up your workspace, including removing the Conda environment used for
     testing (which will prevent you from accidentally using an old
     environment when you should have a fresh up-to-date one next time).

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -1,35 +1,28 @@
 # How to issue an ActivitySim release
 
-> **WARNING: These instructions are incomplete.**
-
-01. Check that the branch you intend to release is passing tests on Travis.
-    If it's not passing there you should not release it.
+00. Check that the main branch is passing tests, especially the "core tests" on
+    [GitHub Actions](https://github.com/ActivitySim/activitysim/actions/workflows/core_tests.yml). 
+    It is generally the policy that the main branch should always be passing tests, 
+    becuase PRs must pass tests before they can be merged.  However, it is 
+    possible that tests may fail after a PR is merged, so it is important to
+    double-check that the main branch is passing tests before issuing a release.
 
 00. Start from a completely clean conda environment
     and git repository.  Assuming you have `conda` installed, you can do so
     by starting where ActivitySim is not yet cloned (e.g. in an empty
     directory) and running:
     ```sh
-    conda create -n TEMP-ASIM-DEV python=3.10 git gh -c conda-forge --override-channels
-    conda activate TEMP-ASIM-DEV
+    conda create -p ./TEMP-ASIM-DEV python=3.10 git gh -c conda-forge --override-channels
+    conda activate ./TEMP-ASIM-DEV
     gh auth login   # <--- (only needed if gh is not logged in)
     gh repo clone ActivitySim/activitysim
     cd activitysim
     ```
 
-00. Per project policy, code on the main branch should have been released,
-    but if you are *preparing* a release then the code should be on the `develop`
-    branch.  Switch to that branch now, and make sure it is synced to the
-    version on GitHub:
-    ```sh
-    git switch develop
-    git pull
-    ```
-
 00. Update your Conda environment for testing.  We do not want to use an
-    existing environment on your machine, as it may be out-of-date
+    existing environment on your machine, as it may be out-of-sync
     and we want to make sure everything passes muster using the
-    most up-to-date dependencies available.  The following command
+    dependencies as they are available today.  The following command
     will update the active environment (we made this to be `TEMP-ASIM-DEV`
     if you followed the directions above).
     ```sh
@@ -48,7 +41,7 @@
     black --check --diff .
     ```
 
-00. Run the regular test suite on Windows. Most GitHub Actions tests are done on Linux,
+00. Run the regular test suite on Windows. Most GitHub Actions tests are done on
     Linux (it's faster to start up and run a new clean VM for testing) but most
     users are on Windows, and the test suite should also be run on Windows to
     ensure that it works on that platform as well.  If you
@@ -67,7 +60,7 @@
     ```
 
 00. Test the full-scale regional examples. These examples are big, too
-    large to run on Travis, and will take a lot of time (many hours) to
+    large to run on GitHub Actions, and will take a lot of time (many hours) to
     download and run.
     ```sh
     mkdir tmp-asim
@@ -88,30 +81,13 @@
     There are also demo notebooks for estimation, but their functionality
     is completely tested in the unit tests run previously.
 
-00. Use bump2version to tag the release commit and update the
-    version number.  The following code will generate a "patch" release,
-    incrementing the third value in the version number (i.e. "1.2.3"
-    becomes "1.2.4").  Alternatively, make a "minor" or "major" release.
-    The `--list` command will generate output to your console to confirm
-    that the old and new version numbers are what you expect, before you
-    push the commit (with the changed version in the code) and tags to
-    GitHub.
+00. Tag the release commit with the new version number.  ActivitySim uses
+    dynamic versioning, so the version number is not stored in a file but
+    is instead read from the most recent git tag, so it is important to tag
+    the repository with the correct version.  The following command will 
+    generate a new tag with the version number "1.2.3" (for example):
     ```sh
-    bump2version patch --list
-    ```
-
-    It is also possible to make a development pre-release. To do so,
-    explicitly set the version number to the next patch plus a ".devN"
-    suffix:
-
-    ```sh
-    bump2version patch --new-version 1.2.3.dev0 --list
-    ```
-
-    Then, when ready to make a "final" release, set the version by
-    explicitly removing the suffix:
-    ```sh
-    bump2version patch --new-version 1.2.3 --list
+    git -a v1.2.3 -m "Release v1.2.3"
     ```
 
 00. Push the tagged commit to GitHub.
@@ -119,44 +95,27 @@
     git push --tags
     ```
 
-00. For non-development releases, open a pull request to merge the proposed
-    release into main. The following command will open a web browser for
-    you to create the pull request.
-    ```sh
-    gh pr create --web
-    ```
-    After creating the PR, confirm with the ActivitySim PMC that the release
-    is ready before actually merging it.
-
-    Once final approval is granted, merge the PR into main.  The presence
-    of the git tags added earlier will trigger automated build steps to
-    prepare and deploy the release to pypi and conda-forge.
-
-00. Create a "release" on GitHub.
+00. Create a "release" on GitHub.  You can do this from the command line using
+    the `gh` command line tool:
     ```sh
     gh release create v1.2.3
     ```
+    But it may be easier to do this through the 
+    [GitHub web interface](https://github.com/ActivitySim/activitysim/releases/new),
+    where you can select the tag you just created and add a title and description.
+    Both the interactive command line tool shown above and the web interface include
+    the ability to create release notes automatically from the commit messages of
+    all accepted PRs since the last release, but you may want to add additional
+    notes to the release to highlight important changes or new features.
+
     The process of creating and tagging a release will automatically
     trigger various GitHub Actions scripts to build, test, and publish the
     new release to PyPI and conda forge, assuming there are no errors.
-
-    For a development pre-release, include the `--prerelease` argument.
-    As the project's policy is that only formally released code is merged
-    to the main branch, any pre-release should also be built against a
-    non-default branch.  For example, to pre-release from the `develop`
-    branch:
-    ```sh
-    gh release create v1.2.3.dev0 \
-        --prerelease \
-        --target develop \
-        --notes "this pre-release is for a cool new feature" \
-        --title "Development Pre-Release"
-    ```
 
 00. Clean up your workspace, including removing the Conda environment used for
     testing (which will prevent you from accidentally using an old
     environment when you should have a fresh up-to-date one next time).
     ```sh
     conda deactivate
-    conda env remove -n TEMP-ASIM-DEV
+    conda env remove -p ./TEMP-ASIM-DEV
     ```


### PR DESCRIPTION
This pull request includes several updates to GitHub Actions workflows and documentation improvements. Key changes involve updating permissions, dependencies, and instructions for releasing the software.

### GitHub Actions Workflow Updates:
* [`.github/workflows/branch-docs.yml`](diffhunk://#diff-cfbbfdfeb3df9cb70af98df05e62e67a31c64d53386e8fdeecbac4be9934d9f4R14-R15): Added `contents: write` permission to the `ubuntu-latest py3.10` job and updated `peaceiris/actions-gh-pages` to version 4. [[1]](diffhunk://#diff-cfbbfdfeb3df9cb70af98df05e62e67a31c64d53386e8fdeecbac4be9934d9f4R14-R15) [[2]](diffhunk://#diff-cfbbfdfeb3df9cb70af98df05e62e67a31c64d53386e8fdeecbac4be9934d9f4L63-R65)
* [`.github/workflows/core_tests.yml`](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R12-R15): Added `workflow_dispatch` trigger, reset `CACHE_NUMBER` to 0, and updated the `setup-miniconda` step to include `auto-update-conda: true` and `conda-solver: classic`. [[1]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R12-R15) [[2]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R34-R36) [[3]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R119-R121) [[4]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R202-R204) [[5]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R290-R292) [[6]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R353-R355) [[7]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R405-R407) [[8]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545R449-R450) [[9]](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L475-R491)

### Documentation Improvements:
* [`HOW_TO_RELEASE.md`](diffhunk://#diff-cb3e92f3c5228ff7283401cb2c01e12382a906bd1f75e3827b510ade272b14adL3-R25): Updated the release instructions to reflect the current process, including checking tests on GitHub Actions, using dynamic versioning, and creating releases through the GitHub web interface or `gh` CLI tool. [[1]](diffhunk://#diff-cb3e92f3c5228ff7283401cb2c01e12382a906bd1f75e3827b510ade272b14adL3-R25) [[2]](diffhunk://#diff-cb3e92f3c5228ff7283401cb2c01e12382a906bd1f75e3827b510ade272b14adL51-R44) [[3]](diffhunk://#diff-cb3e92f3c5228ff7283401cb2c01e12382a906bd1f75e3827b510ade272b14adL70-R63) [[4]](diffhunk://#diff-cb3e92f3c5228ff7283401cb2c01e12382a906bd1f75e3827b510ade272b14adL91-R127)