### PR TITLE
Use pandas 2 for docbuild environment

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - '*'
-  
+
   workflow_dispatch:
 
 env:
@@ -454,7 +454,7 @@ jobs:
           python -m pytest activitysim/estimation/test/test_larch_estimation.py --durations=0
 
   develop-docbuild:
-    needs: foundation
+    # needs: foundation # don't block for now...
     if: github.ref_name == 'main' || github.ref_name == 'docs-fix'
     name: develop-docbuild
     runs-on: ubuntu-latest

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -455,7 +455,7 @@ jobs:
 
   develop-docbuild:
     needs: foundation
-    if: github.ref_name == 'main'
+    if: github.ref_name == 'main' || github.ref_name == 'docs-fix'
     name: develop-docbuild
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -454,7 +454,7 @@ jobs:
           python -m pytest activitysim/estimation/test/test_larch_estimation.py --durations=0
 
   develop-docbuild:
-    # needs: foundation # don't block for now...
+    needs: foundation
     if: github.ref_name == 'main' || github.ref_name == 'docs-fix'
     name: develop-docbuild
     runs-on: ubuntu-latest

--- a/activitysim/abm/misc.py
+++ b/activitysim/abm/misc.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 @workflow.cached_object
 def households_sample_size(state: workflow.State, override_hh_ids) -> int:
-
     if override_hh_ids is None:
         return state.settings.households_sample_size
     else:
@@ -27,7 +26,6 @@ def households_sample_size(state: workflow.State, override_hh_ids) -> int:
 
 @workflow.cached_object
 def override_hh_ids(state: workflow.State) -> np.ndarray | None:
-
     hh_ids_filename = state.settings.hh_ids
     if hh_ids_filename is None:
         return None
@@ -65,7 +63,6 @@ def override_hh_ids(state: workflow.State) -> np.ndarray | None:
 
 @workflow.cached_object
 def trace_od(state: workflow.State) -> tuple[int, int] | None:
-
     od = state.settings.trace_od
 
     if od and not (

--- a/activitysim/abm/models/auto_ownership.py
+++ b/activitysim/abm/models/auto_ownership.py
@@ -72,7 +72,6 @@ def auto_ownership_simulate(
     # - preprocessor
     preprocessor_settings = model_settings.preprocessor
     if preprocessor_settings:
-
         locals_d = {}
         if constants is not None:
             locals_d.update(constants)

--- a/activitysim/abm/models/initialize.py
+++ b/activitysim/abm/models/initialize.py
@@ -148,7 +148,6 @@ def initialize_households(
     model_settings_file_name: str = "initialize_households.yaml",
     trace_label: str = "initialize_households",
 ) -> None:
-
     with chunk.chunk_log(state, trace_label, base=True) as chunk_sizer:
         chunk_sizer.log_rss(f"{trace_label}.inside-yield")
 

--- a/activitysim/abm/models/input_checker.py
+++ b/activitysim/abm/models/input_checker.py
@@ -209,7 +209,6 @@ def validate_with_pydantic(
 
 
 def report_errors(state, input_checker_settings, v_warnings, v_errors):
-
     # logging overall statistics first before printing details
     for table_settings in input_checker_settings["table_list"]:
         table_name = table_settings["name"]

--- a/activitysim/abm/models/non_mandatory_tour_frequency.py
+++ b/activitysim/abm/models/non_mandatory_tour_frequency.py
@@ -236,7 +236,6 @@ def non_mandatory_tour_frequency(
     # - preprocessor
     preprocessor_settings = model_settings.preprocessor
     if preprocessor_settings:
-
         locals_dict = {
             "person_max_window": lambda x: person_max_window(state, x),
             "person_available_periods": lambda persons, start_bin, end_bin, continuous: person_available_periods(

--- a/activitysim/abm/models/trip_purpose_and_destination.py
+++ b/activitysim/abm/models/trip_purpose_and_destination.py
@@ -69,7 +69,6 @@ def trip_purpose_and_destination(
     model_settings_file_name: str = "trip_purpose_and_destination.yaml",
     trace_label: str = "trip_purpose_and_destination",
 ) -> None:
-
     if model_settings is None:
         model_settings = TripPurposeAndDestinationSettings.read_settings_file(
             state.filesystem,

--- a/activitysim/abm/models/trip_scheduling_choice.py
+++ b/activitysim/abm/models/trip_scheduling_choice.py
@@ -358,7 +358,6 @@ def trip_scheduling_choice(
     model_settings_file_name: str = "trip_scheduling_choice.yaml",
     trace_label: str = "trip_scheduling_choice",
 ) -> None:
-
     if model_settings is None:
         model_settings = TripSchedulingChoiceSettings.read_settings_file(
             state.filesystem,
@@ -416,7 +415,6 @@ def trip_scheduling_choice(
     }
 
     if preprocessor_settings:
-
         simulate.set_skim_wrapper_targets(tours_df, skims)
 
         expressions.assign_columns(

--- a/activitysim/abm/models/util/cdap.py
+++ b/activitysim/abm/models/util/cdap.py
@@ -297,7 +297,6 @@ def cached_joint_spec_name(hhsize):
 
 
 def get_cached_spec(state: workflow.State, hhsize):
-
     spec_name = cached_spec_name(hhsize)
 
     spec = state.get_injectable(spec_name, None)
@@ -319,7 +318,6 @@ def get_cached_spec(state: workflow.State, hhsize):
 
 
 def get_cached_joint_spec(state: workflow.State, hhsize):
-
     spec_name = cached_joint_spec_name(hhsize)
 
     spec = state.get_injectable(spec_name, None)
@@ -625,7 +623,6 @@ def build_cdap_joint_spec(
     #         N_p1  0.0  0.0  0.0  1.0  1.0  1.0  0.0  0.0  0.0
     for pnum in range(1, hhsize + 1):
         for activity in ["M", "N", "H"]:
-
             new_row_index = len(spec)
             spec.loc[new_row_index, expression_name] = add_pn(activity, pnum)
 
@@ -638,7 +635,6 @@ def build_cdap_joint_spec(
 
     # for each row in the joint util table
     for row in joint_tour_coefficients.itertuples():
-
         # if there is no dependencies
         if row.dependency is np.nan:
             expression = row.Expression

--- a/activitysim/abm/models/util/overlap.py
+++ b/activitysim/abm/models/util/overlap.py
@@ -138,7 +138,6 @@ def p2p_time_window_overlap(state: workflow.State, p1_ids, p2_ids):
 
 
 def person_pairs(persons):
-
     p = persons[["household_id", "adult"]].reset_index()
     p2p = pd.merge(p, p, left_on="household_id", right_on="household_id", how="outer")
 
@@ -166,7 +165,6 @@ def person_pairs(persons):
 
 
 def hh_time_window_overlap(state: workflow.State, households, persons):
-
     p2p = person_pairs(persons)
 
     p2p["max_overlap"] = p2p_time_window_overlap(state, p2p.person1, p2p.person2)
@@ -189,7 +187,6 @@ def hh_time_window_overlap(state: workflow.State, households, persons):
 
 
 def person_time_window_overlap(state: workflow.State, persons):
-
     p2p = person_pairs(persons)
 
     p2p["max_overlap"] = p2p_time_window_overlap(state, p2p.person1, p2p.person2)
@@ -224,7 +221,6 @@ def person_time_window_overlap(state: workflow.State, persons):
 
 
 def person_max_window(state: workflow.State, persons):
-
     timetable = state.get_injectable("timetable")
 
     # ndarray with one row per person and one column per time period

--- a/activitysim/abm/models/util/probabilistic_scheduling.py
+++ b/activitysim/abm/models/util/probabilistic_scheduling.py
@@ -93,7 +93,6 @@ def _report_bad_choices(
     # log the indexes of the first MAX_PRINT offending rows
     MAX_PRINT = 0
     for idx in df.index[:MAX_PRINT].values:
-
         row_msg = "%s : failed %s = %s (hh_id = %s)" % (
             trace_label,
             df.index.name,
@@ -113,7 +112,6 @@ def _preprocess_departure_probs(
     depart_alt_base,
     first_trip_in_leg,
 ):
-
     # zero out probs outside earliest-latest window if one exists
     probs_cols = [c for c in probs_spec.columns if c not in probs_join_cols]
     if clip_earliest_latest:
@@ -129,7 +127,6 @@ def _preprocess_departure_probs(
 
 
 def _preprocess_stop_duration_probs(choosers):
-
     # convert wide to long. duration probs are stored in long format so that
     # inbound/outbound duration probs, which both have a 0 alternative, can be
     # stored in a single config file. open to better suggestions here.
@@ -203,7 +200,6 @@ def _preprocess_scheduling_probs(
 def _postprocess_scheduling_choices(
     scheduling_mode, depart_alt_base, choices, choice_cols, choosers
 ):
-
     """
     This method just converts the choice column indexes returned by the
     logit.make_choices() method into actual departure time values that are
@@ -222,7 +218,6 @@ def _postprocess_scheduling_choices(
     # get applied to trip-specific departure and arrival times, so depart_alt_base
     # is a column/series rather than a scalar.
     if scheduling_mode == "stop_duration":
-
         # for outbound trips, offsets get added to the departure time constraint
         if choosers.outbound.all():
             depart_alt_base = choosers["earliest"]

--- a/activitysim/abm/models/util/test/test_input_checker.py
+++ b/activitysim/abm/models/util/test/test_input_checker.py
@@ -7,11 +7,11 @@ import os.path
 
 import pandas as pd
 import pandas.testing as pdt
+import pandera as pa
 import pytest
 import yaml
-import pandera as pa
 
-from activitysim.abm.models.input_checker import validate_with_pandera, TABLE_STORE
+from activitysim.abm.models.input_checker import TABLE_STORE, validate_with_pandera
 
 
 @pytest.fixture(scope="class")
@@ -56,7 +56,6 @@ TABLE_STORE["households"] = pd.DataFrame(
 
 
 def test_passing_dataframe(households, v_errors, v_warnings, validation_settings):
-
     TABLE_STORE["households"] = households
 
     class input_checker:
@@ -83,7 +82,6 @@ def test_passing_dataframe(households, v_errors, v_warnings, validation_settings
 
 
 def test_error_dataframe(households, v_errors, v_warnings, validation_settings):
-
     TABLE_STORE["households"] = households
 
     class input_checker:
@@ -107,7 +105,6 @@ def test_error_dataframe(households, v_errors, v_warnings, validation_settings):
 
 
 def test_warning_dataframe(households, v_errors, v_warnings, validation_settings):
-
     TABLE_STORE["households"] = households
 
     class input_checker:
@@ -132,7 +129,6 @@ def test_warning_dataframe(households, v_errors, v_warnings, validation_settings
 def test_custom_check_failure_dataframe(
     households, v_errors, v_warnings, validation_settings
 ):
-
     TABLE_STORE["households"] = households
 
     class input_checker:

--- a/activitysim/abm/models/util/trip.py
+++ b/activitysim/abm/models/util/trip.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 def failed_trip_cohorts(trips, failed):
-
     # outbound trips in a tour with a failed outbound trip
     bad_outbound_trips = trips.outbound & (
         trips.tour_id.isin(trips.tour_id[failed & trips.outbound])

--- a/activitysim/abm/tables/households.py
+++ b/activitysim/abm/tables/households.py
@@ -127,7 +127,6 @@ def households_merged(
     land_use: pd.DataFrame,
     accessibility: pd.DataFrame,
 ) -> pd.DataFrame:
-
     households = simple_table_join(
         households,
         land_use,

--- a/activitysim/abm/tables/table_dict.py
+++ b/activitysim/abm/tables/table_dict.py
@@ -18,13 +18,11 @@ should be registered as random number generator channels.
 
 @workflow.cached_object
 def rng_channels(state: workflow.State):
-
     return cid.RANDOM_CHANNELS
 
 
 @workflow.cached_object
 def traceable_tables(state: workflow.State):
-
     # names of all traceable tables ordered by dependency on household_id
     # e.g. 'persons' has to be registered AFTER 'households'
 

--- a/activitysim/abm/test/run_multi_zone_mp.py
+++ b/activitysim/abm/test/run_multi_zone_mp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # ActivitySim
 # See full license in LICENSE.txt.
 import os
@@ -13,7 +15,6 @@ HOUSEHOLDS_SAMPLE_SIZE = 100
 
 
 def test_mp_run():
-
     configs_dir = [example_path("configs_3_zone"), example_path("configs")]
     data_dir = example_path("data_3")
 
@@ -34,5 +35,4 @@ def test_mp_run():
 
 
 if __name__ == "__main__":
-
     test_mp_run()

--- a/activitysim/abm/test/test_misc/setup_utils.py
+++ b/activitysim/abm/test/test_misc/setup_utils.py
@@ -36,7 +36,6 @@ def example_path(dirname):
 
 
 def setup_dirs(ancillary_configs_dir=None, data_dir=None):
-
     # ancillary_configs_dir is used by run_mp to test multiprocess
 
     # test_pipeline_configs_dir = os.path.join(os.path.dirname(__file__), "configs")
@@ -69,7 +68,6 @@ def setup_dirs(ancillary_configs_dir=None, data_dir=None):
 
 
 def close_handlers():
-
     loggers = logging.Logger.manager.loggerDict
     for name in loggers:
         logger = logging.getLogger(name)

--- a/activitysim/abm/test/test_pipeline/test_pipeline.py
+++ b/activitysim/abm/test/test_pipeline/test_pipeline.py
@@ -34,7 +34,6 @@ def example_path(dirname):
 
 
 def setup_dirs(ancillary_configs_dir=None, data_dir=None):
-
     # ancillary_configs_dir is used by run_mp to test multiprocess
 
     test_pipeline_configs_dir = os.path.join(os.path.dirname(__file__), "configs")
@@ -66,7 +65,6 @@ def setup_dirs(ancillary_configs_dir=None, data_dir=None):
 
 
 def close_handlers():
-
     loggers = logging.Logger.manager.loggerDict
     for name in loggers:
         logger = logging.getLogger(name)
@@ -76,7 +74,6 @@ def close_handlers():
 
 
 def test_rng_access():
-
     state = setup_dirs()
     state.settings.rng_base_seed = 0
 
@@ -90,7 +87,6 @@ def test_rng_access():
 
 
 def regress_mini_auto(state: workflow.State):
-
     # regression test: these are among the middle households in households table
     # should be the same results as in run_mp (multiprocessing) test case
     hh_ids = [1099626, 1173905, 1196298, 1286259]
@@ -123,7 +119,6 @@ def regress_mini_auto(state: workflow.State):
 
 
 def regress_mini_mtf(state: workflow.State):
-
     mtf_choice = (
         state.checkpoint.load_dataframe("persons").sort_index().mandatory_tour_frequency
     )
@@ -156,7 +151,6 @@ def regress_mini_mtf(state: workflow.State):
 
 
 def regress_mini_location_choice_logsums(state: workflow.State):
-
     persons = state.checkpoint.load_dataframe("persons")
 
     # DEST_CHOICE_LOGSUM_COLUMN_NAME is specified in school_location.yaml and should be assigned
@@ -168,7 +162,6 @@ def regress_mini_location_choice_logsums(state: workflow.State):
 
 
 def test_mini_pipeline_run():
-
     from activitysim.abm.tables.skims import network_los_preload
 
     state = setup_dirs()
@@ -217,7 +210,6 @@ def test_mini_pipeline_run():
 
 
 def test_mini_pipeline_run2():
-
     # the important thing here is that we should get
     # exactly the same results as for test_mini_pipeline_run
     # when we restart pipeline
@@ -270,7 +262,6 @@ def test_mini_pipeline_run2():
 
 
 def test_mini_pipeline_run3():
-
     # test that hh_ids setting overrides household sampling
 
     state = setup_dirs()
@@ -300,7 +291,6 @@ def full_run(
     trace_od=None,
     check_for_variability=False,
 ):
-
     state = setup_dirs()
 
     state.settings.households_sample_size = households_sample_size
@@ -328,7 +318,6 @@ EXPECT_TOUR_COUNT = 121
 
 
 def regress_tour_modes(tours_df):
-
     mode_cols = ["tour_mode", "person_id", "tour_type", "tour_num", "tour_category"]
 
     tours_df = tours_df[tours_df.household_id == HH_ID]
@@ -376,7 +365,6 @@ def regress_tour_modes(tours_df):
 
 
 def regress(state: workflow.State):
-
     persons_df = state.checkpoint.load_dataframe("persons")
     persons_df = persons_df[persons_df.household_id == HH_ID]
     print("persons_df\n%s" % persons_df[["value_of_time", "distance_to_work"]])
@@ -443,7 +431,6 @@ def regress(state: workflow.State):
 
 
 def test_full_run1():
-
     if SKIP_FULL_RUN:
         return
 
@@ -465,7 +452,6 @@ def test_full_run1():
 
 
 def test_full_run2():
-
     # resume_after should successfully load tours table and replicate results
 
     if SKIP_FULL_RUN:
@@ -485,7 +471,6 @@ def test_full_run2():
 
 
 def test_full_run3_with_chunks():
-
     # should get the same result with different chunk size
 
     if SKIP_FULL_RUN:
@@ -507,7 +492,6 @@ def test_full_run3_with_chunks():
 
 
 def test_full_run4_stability():
-
     # hh should get the same result with different sample size
 
     if SKIP_FULL_RUN:
@@ -523,7 +507,6 @@ def test_full_run4_stability():
 
 
 def test_full_run5_singleton():
-
     # should work with only one hh
     # run with minimum chunk size to drive potential chunking errors in models
     # where choosers has multiple rows that all have to be included in the same chunk
@@ -541,7 +524,6 @@ def test_full_run5_singleton():
 
 
 if __name__ == "__main__":
-
     print("running test_full_run1")
     test_full_run1()
     # teardown_function(None)

--- a/activitysim/benchmarking/latest.py
+++ b/activitysim/benchmarking/latest.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    annotations,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import logging
 import shlex
@@ -149,7 +155,7 @@ class Latest(Run):
             pull=not args.no_pull,
             interleave_processes=args.interleave_processes,
             launch_method=args.launch_method,
-            **kwargs
+            **kwargs,
         )
 
 

--- a/activitysim/benchmarking/profile_inspector.py
+++ b/activitysim/benchmarking/profile_inspector.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import contextlib
 import io
@@ -51,7 +53,6 @@ def benchmark_snakeviz(json_record, benchmark=None):
         except KeyboardInterrupt:
             pass
         except Exception:
-
             traceback.print_exc()
             input(input("Press Enter to continue..."))
         finally:

--- a/activitysim/cli/main.py
+++ b/activitysim/cli/main.py
@@ -6,7 +6,6 @@ import sys
 
 
 def prog():
-
     from activitysim import __doc__, __version__, workflows
     from activitysim.cli import CLI, benchmark, create, exercise, run
 
@@ -45,7 +44,6 @@ def prog():
 
 
 def main():
-
     # set all these before we import numpy or any other math library
     if len(sys.argv) > 1 and sys.argv[1] == "benchmark":
         os.environ["MKL_NUM_THREADS"] = "1"

--- a/activitysim/cli/test/test_cli.py
+++ b/activitysim/cli/test/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # ActivitySim
 # See full license in LICENSE.txt.
 import os
@@ -12,7 +14,6 @@ if sys.version_info < (3, 7):
 
 
 def test_help():
-
     # cp = completed process
     cp = subprocess.run(["activitysim", "-h"], capture_output=True)
 
@@ -20,14 +21,12 @@ def test_help():
 
 
 def test_create_help():
-
     cp = subprocess.run(["activitysim", "create", "-h"], capture_output=True)
 
     assert "usage: activitysim create [-h] (-l | -e PATH) [-d PATH]" in str(cp.stdout)
 
 
 def test_create_list():
-
     cp = subprocess.run(["activitysim", "create", "--list"], capture_output=True)
 
     assert "Available examples" in str(cp.stdout)
@@ -35,7 +34,6 @@ def test_create_list():
 
 
 def test_create_copy():
-
     target = os.path.join(os.path.dirname(__file__), "test_example")
     cp = subprocess.run(
         [
@@ -67,7 +65,6 @@ def test_create_copy():
 
 
 def test_run():
-
     cp = subprocess.run(["activitysim", "run"], capture_output=True)
 
     # expect error
@@ -75,7 +72,6 @@ def test_run():
 
 
 if __name__ == "__main__":
-
     test_help()
     test_create_help()
     test_create_list()

--- a/activitysim/core/assign.py
+++ b/activitysim/core/assign.py
@@ -282,7 +282,6 @@ def assign_variables(
             n_randoms += 1
             assignment_expressions.loc[expression_idx, "expression"] = expression
     if n_randoms:
-
         try:
             random_draws = state.get_rn_generator().normal_for_df(
                 df, broadcast=True, size=n_randoms

--- a/activitysim/core/flow.py
+++ b/activitysim/core/flow.py
@@ -63,7 +63,6 @@ def logtime(tag, tag2=""):
 
 
 class TimeLogger:
-
     aggregate_timing = {}
 
     def __init__(self, tag1):
@@ -662,7 +661,7 @@ def new_flow(
         defs = {}
         # duplicate labels cause problems for sharrow, so we need to dedupe
         existing_labels = set()
-        for (expr, label) in zip(exprs, labels):
+        for expr, label in zip(exprs, labels):
             while label in existing_labels:
                 label = label + "_"
             existing_labels.add(label)
@@ -691,7 +690,7 @@ def new_flow(
         orig_col_name: {orig_col_name}
         dest_col_name: {dest_col_name}
         expressions:"""
-        for (expr, label) in zip(exprs, labels):
+        for expr, label in zip(exprs, labels):
             readme += f"\n            - {label}: {expr}"
         if extra_vars:
             readme += "\n        extra_vars:"

--- a/activitysim/core/interaction_sample.py
+++ b/activitysim/core/interaction_sample.py
@@ -13,8 +13,8 @@ from activitysim.core import (
     logit,
     simulate,
     tracing,
-    workflow,
     util,
+    workflow,
 )
 from activitysim.core.configuration.base import ComputeSettings
 from activitysim.core.skim_dataset import DatasetWrapper
@@ -250,7 +250,6 @@ def _interaction_sample(
     # check if tracing is enabled and if we have trace targets
     # if not estimation mode, drop unused columns
     if (not have_trace_targets) and (compute_settings.drop_unused_columns):
-
         choosers = util.drop_unused_columns(
             choosers,
             spec,

--- a/activitysim/core/interaction_sample_simulate.py
+++ b/activitysim/core/interaction_sample_simulate.py
@@ -7,8 +7,7 @@ import logging
 import numpy as np
 import pandas as pd
 
-
-from activitysim.core import chunk, interaction_simulate, logit, tracing, workflow, util
+from activitysim.core import chunk, interaction_simulate, logit, tracing, util, workflow
 from activitysim.core.configuration.base import ComputeSettings
 from activitysim.core.simulate import set_skim_wrapper_targets
 
@@ -151,7 +150,6 @@ def _interaction_sample_simulate(
         and (estimator is None)
         and (compute_settings.drop_unused_columns)
     ):
-
         choosers = util.drop_unused_columns(
             choosers,
             spec,

--- a/activitysim/core/interaction_simulate.py
+++ b/activitysim/core/interaction_simulate.py
@@ -743,7 +743,6 @@ def _interaction_simulate(
         and (estimator is None)
         and (compute_settings.drop_unused_columns)
     ):
-
         choosers = util.drop_unused_columns(
             choosers,
             spec,

--- a/activitysim/core/logit.py
+++ b/activitysim/core/logit.py
@@ -72,7 +72,6 @@ def report_bad_choices(
 
     # log the indexes of the first MAX_DUMP offending rows
     for idx in df.index[:MAX_PRINT].values:
-
         row_msg = "%s : %s in: %s = %s (hh_id = %s)" % (
             trace_label,
             msg,
@@ -313,7 +312,6 @@ def make_choices(
     ).abs() > BAD_PROB_THRESHOLD * np.ones(len(probs.index))
 
     if bad_probs.any() and not allow_bad_probs:
-
         report_bad_choices(
             state,
             bad_probs,
@@ -458,7 +456,6 @@ class Nest:
 
 
 def validate_nest_spec(nest_spec: dict | LogitNestSpec, trace_label: str):
-
     keys = []
     duplicates = []
     for nest in each_nest(nest_spec):

--- a/activitysim/core/mem.py
+++ b/activitysim/core/mem.py
@@ -147,7 +147,6 @@ def consolidate_logs(state: workflow.State):
 
 
 def check_global_hwm(tag, value, label):
-
     assert value is not None
 
     hwm = GLOBAL_HWM.setdefault(tag, {})
@@ -164,7 +163,6 @@ def check_global_hwm(tag, value, label):
 
 
 def log_global_hwm():
-
     process_name = multiprocessing.current_process().name
 
     for tag in GLOBAL_HWM:
@@ -177,7 +175,6 @@ def log_global_hwm():
 
 
 def trace_memory_info(event, trace_ticks=0, force_garbage_collect=False, *, state):
-
     global MEM_TICK
 
     if state is None:
@@ -232,7 +229,6 @@ def trace_memory_info(event, trace_ticks=0, force_garbage_collect=False, *, stat
     noteworthy = check_global_hwm("uss", uss, event) or noteworthy
 
     if noteworthy:
-
         # logger.debug(f"trace_memory_info {event} "
         #              f"rss: {GB(full_rss) if num_children else GB(rss)} "
         #              f"uss: {GB(rss)} ")
@@ -266,7 +262,6 @@ def trace_memory_info(event, trace_ticks=0, force_garbage_collect=False, *, stat
 
 
 def get_rss(force_garbage_collect=False, uss=False):
-
     if force_garbage_collect:
         was_disabled = not gc.isenabled()
         if was_disabled:

--- a/activitysim/core/memory_sidecar.py
+++ b/activitysim/core/memory_sidecar.py
@@ -11,7 +11,6 @@ import psutil
 def record_memory_usage(
     logstream, event="", event_idx=-1, measure_uss=False, measure_cpu=False, pid=None
 ):
-
     if pid is None:
         pid = os.getpid()
     current_process = psutil.Process(pid)

--- a/activitysim/core/pathbuilder_cache.py
+++ b/activitysim/core/pathbuilder_cache.py
@@ -70,7 +70,6 @@ class TVPBCache(object):
     """
 
     def __init__(self, network_los: "los.Network_LOS", uid_calculator, cache_tag):
-
         # lightweight until opened
 
         self.cache_tag = cache_tag
@@ -121,7 +120,6 @@ class TVPBCache(object):
                         break
 
     def write_static_cache(self, data):
-
         assert not self.is_open
         assert self._data is None
         assert not self.is_changed
@@ -336,7 +334,6 @@ class TapTapUidCalculator:
     """
 
     def __init__(self, network_los):
-
         self.network_los = network_los
 
         # ensure that tap_df has been loaded
@@ -420,7 +417,6 @@ class TapTapUidCalculator:
 
         # need to know cardinality and integer representation of each tap/attribute
         for name, ordinalizer in self.ordinalizers.items():
-
             cardinality = ordinalizer.max() + 1
 
             if name in df:
@@ -484,7 +480,6 @@ class TapTapUidCalculator:
         # attribute names as list of strings
         attribute_names = list(self.segmentation.keys())
         for attribute_value_tuple in self.attribute_combination_tuples:
-
             # attribute_value_tuple is an tuple of attribute values - e.g. (0, 'AM', 'walk')
             # build dict of attribute name:value pairs - e.g. {'demographic_segment': 0, 'tod': 'AM', })
             scalar_attributes = {

--- a/activitysim/core/skim_dict_factory.py
+++ b/activitysim/core/skim_dict_factory.py
@@ -114,11 +114,9 @@ class SkimInfo(object):
         self.omx_manifest = {}  # dict mapping { omx_key: skim_name }
 
         for omx_file_path in self.omx_file_paths:
-
             logger.debug(f"load_skim_info {skim_tag} reading {omx_file_path}")
 
             with omx.open_file(omx_file_path, mode="r") as omx_file:
-
                 # fixme call to omx_file.shape() failing in windows p3.5
                 if self.omx_shape is None:
                     self.omx_shape = tuple(
@@ -190,7 +188,6 @@ class SkimInfo(object):
         # ('DRV_COM_WLK_BOARDS', 'MD') 4, ...
         self.block_offsets = dict()
         for skim_key in self.omx_keys:
-
             if isinstance(skim_key, tuple):
                 key1, key2 = skim_key
             else:
@@ -281,7 +278,6 @@ class AbstractSkimFactory(ABC):
         omx_manifest = skim_info.omx_manifest  # dict mapping { omx_key: skim_name }
 
         for omx_file_path in skim_info.omx_file_paths:
-
             num_skims_loaded = 0
 
             logger.info(f"_read_skims_from_omx {omx_file_path}")
@@ -289,9 +285,7 @@ class AbstractSkimFactory(ABC):
             # read skims into skim_data
             with omx.open_file(omx_file_path, mode="r") as omx_file:
                 for skim_key, omx_key in omx_keys.items():
-
                     if omx_manifest[omx_key] == omx_file_path:
-
                         offset = skim_info.block_offsets[skim_key]
                         logger.debug(
                             f"_read_skims_from_omx file {omx_file_path} omx_key {omx_key} "
@@ -366,7 +360,6 @@ class AbstractSkimFactory(ABC):
         return data
 
     def copy_omx_to_mmap_file(self, skim_info):
-
         skim_data = self._create_empty_writable_memmap_skim_cache(skim_info)
         self._read_skims_from_omx(skim_info, skim_data)
         skim_data._mmap.close()

--- a/activitysim/core/skim_dictionary.py
+++ b/activitysim/core/skim_dictionary.py
@@ -1,10 +1,10 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 from __future__ import annotations
-from collections import OrderedDict
 
 import logging
 from builtins import object, range
+from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -38,7 +38,6 @@ class OffsetMapper(object):
     """
 
     def __init__(self, offset_int=None, offset_list=None, offset_series=None):
-
         self.offset_int = self.offset_series = None
 
         assert (offset_int is not None) + (offset_list is not None) + (
@@ -160,7 +159,6 @@ class SkimDict:
     """
 
     def __init__(self, state, skim_tag, skim_info, skim_data):
-
         logger.info(f"SkimDict init {skim_tag}")
 
         self.skim_tag = skim_tag
@@ -772,7 +770,6 @@ class MazSkimDict(SkimDict):
         is_nan = np.isnan(values)
 
         if max_blend_distance > 0:
-
             # print(f"{is_nan.sum()} nans out of {len(is_nan)} for key '{self.key}")
             # print(f"blend_distance_skim_name {self.blend_distance_skim_name}")
 
@@ -802,7 +799,6 @@ class MazSkimDict(SkimDict):
             # print(f"{is_nan.sum()} nans out of {len(is_nan)} for key '{self.key}")
 
             if key in self.base_keys:
-
                 # replace nan values using simple backstop without blending
                 backstop_values = super().lookup(orig, dest, key)
                 values = np.where(is_nan, backstop_values, values)

--- a/activitysim/core/test/extensions/steps.py
+++ b/activitysim/core/test/extensions/steps.py
@@ -7,28 +7,24 @@ from activitysim.core import workflow
 
 @workflow.step
 def step1(state: workflow.State) -> None:
-
     table1 = pd.DataFrame({"c": [1, 2, 3]})
     state.add_table("table1", table1)
 
 
 @workflow.step
 def step2(state: workflow.State) -> None:
-
     table1 = pd.DataFrame({"c": [2, 4, 6]})
     state.add_table("table2", table1)
 
 
 @workflow.step
 def step3(state: workflow.State) -> None:
-
     table1 = pd.DataFrame({"c": [3, 6, 9]})
     state.add_table("table3", table1)
 
 
 @workflow.step
 def step_add_col(state: workflow.State) -> None:
-
     table_name = state.get_step_arg("table_name")
     assert table_name is not None
 
@@ -46,7 +42,6 @@ def step_add_col(state: workflow.State) -> None:
 
 @workflow.step
 def step_forget_tab(state: workflow.State) -> None:
-
     table_name = state.get_step_arg("table_name")
     assert table_name is not None
 
@@ -57,7 +52,6 @@ def step_forget_tab(state: workflow.State) -> None:
 
 @workflow.step
 def create_households(state: workflow.State) -> None:
-
     df = pd.DataFrame({"household_id": [1, 2, 3], "home_zone_id": {100, 100, 101}})
     state.add_table("households", df)
 

--- a/activitysim/core/test/test_assign.py
+++ b/activitysim/core/test/test_assign.py
@@ -14,7 +14,6 @@ from activitysim.core import assign, workflow
 
 
 def close_handlers():
-
     loggers = logging.Logger.manager.loggerDict
     for name in loggers:
         logger = logging.getLogger(name)

--- a/activitysim/core/test/test_inject_defaults.py
+++ b/activitysim/core/test/test_inject_defaults.py
@@ -15,7 +15,6 @@ from activitysim.core.exceptions import StateAccessError
 
 
 def test_defaults():
-
     state = workflow.State()
     with pytest.raises(ValidationError):
         state.initialize_filesystem(working_dir=Path(__file__).parents[1])

--- a/activitysim/core/test/test_input.py
+++ b/activitysim/core/test/test_input.py
@@ -48,7 +48,6 @@ def state():
 
 
 def test_missing_table_list(state):
-
     state.load_settings()
     assert isinstance(state.settings, configuration.Settings)
 
@@ -58,7 +57,6 @@ def test_missing_table_list(state):
 
 
 def test_csv_reader(seed_households, state):
-
     settings_yaml = """
         input_table_list:
           - tablename: households
@@ -83,7 +81,6 @@ def test_csv_reader(seed_households, state):
 
 
 def test_hdf_reader1(seed_households, state):
-
     settings_yaml = """
         input_table_list:
           - tablename: households
@@ -108,7 +105,6 @@ def test_hdf_reader1(seed_households, state):
 
 
 def test_hdf_reader2(seed_households, state):
-
     settings_yaml = """
         input_table_list:
           - tablename: households
@@ -134,7 +130,6 @@ def test_hdf_reader2(seed_households, state):
 
 
 def test_hdf_reader3(seed_households, state):
-
     settings_yaml = """
         input_store: input_data.h5
         input_table_list:
@@ -159,7 +154,6 @@ def test_hdf_reader3(seed_households, state):
 
 
 def test_missing_filename(seed_households, state):
-
     settings_yaml = """
         input_table_list:
           - tablename: households
@@ -178,7 +172,6 @@ def test_missing_filename(seed_households, state):
 
 
 def test_create_input_store(seed_households, state):
-
     settings_yaml = """
         create_input_store: True
         input_table_list:

--- a/activitysim/core/test/test_logging.py
+++ b/activitysim/core/test/test_logging.py
@@ -114,7 +114,6 @@ logging_config_content = {
 
 @pytest.mark.parametrize("logging_yaml", logging_config_content.keys())
 def test_config_logger(capsys, logging_yaml):
-
     print(logging_config_content[logging_yaml])
 
     state = workflow.State.make_temp()

--- a/activitysim/core/test/test_los.py
+++ b/activitysim/core/test/test_los.py
@@ -15,7 +15,6 @@ from activitysim.core import exceptions, los, workflow
 
 
 def add_canonical_dirs(configs_dir_name):
-
     state = workflow.State()
     configs_dir = os.path.join(os.path.dirname(__file__), f"los/{configs_dir_name}")
     data_dir = os.path.join(os.path.dirname(__file__), f"los/data")
@@ -30,7 +29,6 @@ def add_canonical_dirs(configs_dir_name):
 
 
 def test_legacy_configs():
-
     state = add_canonical_dirs("configs_legacy_settings").load_settings()
 
     with pytest.raises(exceptions.SettingsFileNotFoundError):
@@ -42,7 +40,6 @@ def test_legacy_configs():
 
 
 def test_one_zone():
-
     state = add_canonical_dirs("configs_1z").load_settings()
 
     network_los = los.Network_LOS(state)
@@ -88,7 +85,6 @@ def test_one_zone():
 
 
 def test_two_zone():
-
     state = add_canonical_dirs("configs_2z").load_settings()
 
     network_los = los.Network_LOS(state)
@@ -138,7 +134,6 @@ def test_two_zone():
 
 
 def test_three_zone():
-
     state = add_canonical_dirs("configs_3z").load_settings()
 
     network_los = los.Network_LOS(state)
@@ -163,7 +158,6 @@ def test_three_zone():
 
 
 def test_30_minute_windows():
-
     state = add_canonical_dirs("configs_test_misc").default_settings()
     network_los = los.Network_LOS(state, los_settings_file_name="settings_30_min.yaml")
 
@@ -180,7 +174,6 @@ def test_30_minute_windows():
 
 
 def test_60_minute_windows():
-
     state = add_canonical_dirs("configs_test_misc").default_settings()
     network_los = los.Network_LOS(state, los_settings_file_name="settings_60_min.yaml")
 
@@ -197,7 +190,6 @@ def test_60_minute_windows():
 
 
 def test_1_week_time_window():
-
     state = add_canonical_dirs("configs_test_misc").default_settings()
     network_los = los.Network_LOS(state, los_settings_file_name="settings_1_week.yaml")
 
@@ -228,7 +220,6 @@ def test_1_week_time_window():
 
 
 def test_skim_time_periods_future_warning():
-
     state = add_canonical_dirs("configs_test_misc").default_settings()
 
     with pytest.warns(FutureWarning) as warning_test:

--- a/activitysim/core/test/test_pipeline.py
+++ b/activitysim/core/test/test_pipeline.py
@@ -18,7 +18,6 @@ HH_ID = 961042
 
 @pytest.fixture
 def state():
-
     configs_dir = os.path.join(os.path.dirname(__file__), "configs")
     output_dir = os.path.join(os.path.dirname(__file__), "output")
     data_dir = os.path.join(os.path.dirname(__file__), "data")
@@ -38,7 +37,6 @@ def state():
 
 
 def close_handlers():
-
     loggers = logging.Logger.manager.loggerDict
     for name in loggers:
         logger = logging.getLogger(name)
@@ -49,7 +47,6 @@ def close_handlers():
 
 # @pytest.mark.filterwarnings('ignore::tables.NaturalNameWarning')
 def test_pipeline_run(state):
-
     # workflow.step(steps.step1, step_name="step1")
     # workflow.step(steps.step2, step_name="step2")
     # workflow.step(steps.step3, step_name="step3")
@@ -93,7 +90,6 @@ def test_pipeline_run(state):
 
 
 def test_pipeline_checkpoint_drop(state):
-
     # workflow.step(steps.step1, step_name="step1")
     # workflow.step(steps.step2, step_name="step2")
     # workflow.step(steps.step3, step_name="step3")

--- a/activitysim/core/test/test_random.py
+++ b/activitysim/core/test/test_random.py
@@ -11,7 +11,6 @@ from activitysim.core import random
 
 
 def test_basic():
-
     rng = random.Random()
 
     rng.set_base_seed(0)
@@ -34,7 +33,6 @@ def test_basic():
 
 
 def test_channel():
-
     channels = {
         "households": "household_id",
         "persons": "person_id",

--- a/activitysim/core/test/test_simulate.py
+++ b/activitysim/core/test/test_simulate.py
@@ -43,7 +43,6 @@ def data(data_dir):
 
 
 def test_read_model_spec(state, spec_name):
-
     spec = state.filesystem.read_model_spec(file_name=spec_name)
 
     assert len(spec) == 4
@@ -53,7 +52,6 @@ def test_read_model_spec(state, spec_name):
 
 
 def test_eval_variables(state, spec, data):
-
     result = simulate.eval_variables(state, spec.index, data)
 
     expected = pd.DataFrame(
@@ -72,7 +70,6 @@ def test_eval_variables(state, spec, data):
 
 
 def test_simple_simulate(state, data, spec):
-
     state.settings.check_for_variability = False
 
     choices = simulate.simple_simulate(state, choosers=data, spec=spec, nest_spec=None)
@@ -81,7 +78,6 @@ def test_simple_simulate(state, data, spec):
 
 
 def test_simple_simulate_chunked(state, data, spec):
-
     state.settings.check_for_variability = False
     state.settings.chunk_size = 2
     choices = simulate.simple_simulate(

--- a/activitysim/core/test/test_skim.py
+++ b/activitysim/core/test/test_skim.py
@@ -22,7 +22,6 @@ class FakeSkimInfo(object):
 
 
 def test_skims(data):
-
     # ROW_MAJOR_LAYOUT
     omx_shape = (10, 10)
     num_skims = 2
@@ -61,7 +60,6 @@ def test_skims(data):
 
 
 def test_3dskims(data):
-
     # ROW_MAJOR_LAYOUT
     omx_shape = (10, 10)
     num_skims = 2

--- a/activitysim/core/test/test_timetable.py
+++ b/activitysim/core/test/test_timetable.py
@@ -15,7 +15,6 @@ from activitysim.core import workflow
 
 @pytest.fixture
 def persons():
-
     df = pd.DataFrame(index=list(range(6)))
 
     return df
@@ -55,11 +54,9 @@ def tdd_alts():
 
 
 def test_basic(persons, tdd_alts):
-
     state = workflow.State().default_settings()
 
     with chunk.chunk_log(state, "test_basic", base=True):
-
         person_windows = tt.create_timetable_windows(persons, tdd_alts)
 
         timetable = tt.TimeTable(person_windows, tdd_alts, "person_windows")

--- a/activitysim/core/test/test_tracing.py
+++ b/activitysim/core/test/test_tracing.py
@@ -13,7 +13,6 @@ from activitysim.core import tracing, workflow
 
 
 def close_handlers():
-
     loggers = logging.Logger.manager.loggerDict
     for name in loggers:
         logger = logging.getLogger(name)
@@ -23,7 +22,6 @@ def close_handlers():
 
 
 def add_canonical_dirs():
-
     state = workflow.State()
 
     configs_dir = os.path.join(os.path.dirname(__file__), "configs")
@@ -42,7 +40,6 @@ def add_canonical_dirs():
 
 
 def test_config_logger(capsys):
-
     state = add_canonical_dirs()
 
     state.logging.config_logger()
@@ -81,7 +78,6 @@ def test_config_logger(capsys):
 
 
 def test_print_summary(capsys):
-
     state = add_canonical_dirs()
 
     state.logging.config_logger()
@@ -101,7 +97,6 @@ def test_print_summary(capsys):
 
 
 def test_register_households(capsys):
-
     state = add_canonical_dirs()
     state.load_settings()
 
@@ -130,7 +125,6 @@ def test_register_households(capsys):
 
 
 def test_register_tours(capsys):
-
     state = add_canonical_dirs().load_settings()
 
     state.logging.config_logger()
@@ -178,7 +172,6 @@ def test_register_tours(capsys):
 
 
 def test_write_csv(capsys):
-
     state = add_canonical_dirs()
 
     state.logging.config_logger()
@@ -196,7 +189,6 @@ def test_write_csv(capsys):
 
 
 def test_slice_ids():
-
     df = pd.DataFrame({"household_id": [1, 2, 3]}, index=[11, 12, 13])
 
     # slice by named column
@@ -214,7 +206,6 @@ def test_slice_ids():
 
 
 def test_basic(capsys):
-
     close_handlers()
 
     state = add_canonical_dirs()

--- a/activitysim/core/test/test_util.py
+++ b/activitysim/core/test/test_util.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from ..util import other_than, quick_loc_df, quick_loc_series, reindex, df_from_dict
+from ..util import df_from_dict, other_than, quick_loc_df, quick_loc_series, reindex
 
 
 @pytest.fixture(scope="module")
@@ -41,7 +41,6 @@ def test_reindex():
 
 
 def test_quick_loc_df():
-
     df = pd.DataFrame({"attrib": ["1", "2", "3", "4", "5"]}, index=[1, 2, 3, 4, 5])
 
     loc_list = np.asanyarray([2, 1, 3, 4, 4, 5, 1])
@@ -54,7 +53,6 @@ def test_quick_loc_df():
 
 
 def test_quick_loc_series():
-
     series = pd.Series(["1", "2", "3", "4", "5"], index=[1, 2, 3, 4, 5])
 
     loc_list = np.asanyarray([2, 1, 3, 4, 4, 5, 1])
@@ -65,7 +63,6 @@ def test_quick_loc_series():
 
 
 def test_df_from_dict():
-
     index = [1, 2, 3, 4, 5]
     df = pd.DataFrame({"attrib": [1, 2, 2, 3, 1]}, index=index)
 

--- a/activitysim/core/timetable.py
+++ b/activitysim/core/timetable.py
@@ -176,7 +176,6 @@ def _available_run_length_2(
     available[0] = 0
     available[-1] = 0
     for row in range(num_rows):
-
         row_ix = window_row_mapper[window_row_id_values[row]]
         window_row = windows[row_ix]
         for j in range(1, num_cols - 1):
@@ -205,7 +204,6 @@ def _available_run_length_2(
 
 
 def tour_map(persons, tours, tdd_alts, persons_id_col="person_id"):
-
     sigil = {
         "empty": "   ",
         "overlap": "+++",
@@ -251,7 +249,6 @@ def tour_map(persons, tours, tdd_alts, persons_id_col="person_id"):
     window_periods_df = pd.DataFrame(data=window_periods, index=tdd_alts.index)
 
     for keys, nth_tours in tours.groupby(["tour_type", "tour_type_num"], sort=True):
-
         tour_type = keys[0]
         tour_sigil = sigil[tour_type]
 
@@ -430,7 +427,6 @@ class TimeTable(object):
         return windows
 
     def slice_windows_by_row_id_and_period(self, window_row_ids, periods):
-
         # row ixs of tour_df group rows in windows
         row_ixs = self.window_row_ix.apply_to(window_row_ids)
 
@@ -442,7 +438,6 @@ class TimeTable(object):
         return windows
 
     def get_windows_df(self):
-
         # It appears that assignments into windows write through to underlying pandas table.
         # because we set windows = windows_df.values, and since all the columns are the same type
         # so no need to refresh pandas dataframe, but if we had to it would go here
@@ -611,14 +606,12 @@ class TimeTable(object):
         self.windows[row_ixs] = np.bitwise_or(self.windows[row_ixs], footprints)
 
     def pairwise_available(self, window1_row_ids, window2_row_ids):
-
         available1 = (self.slice_windows_by_row_id(window1_row_ids) != I_MIDDLE) * 1
         available2 = (self.slice_windows_by_row_id(window2_row_ids) != I_MIDDLE) * 1
 
         return available1 * available2
 
     def individually_available(self, window_row_ids):
-
         return (self.slice_windows_by_row_id(window_row_ids) != I_MIDDLE) * 1
 
     def adjacent_window_run_length(self, window_row_ids, periods, before):

--- a/activitysim/core/workflow/logging.py
+++ b/activitysim/core/workflow/logging.py
@@ -128,7 +128,6 @@ class Logging(StateAccessor):
             logger.log(basic, "Configured logging using basicConfig")
 
     def rotate_log_directory(self):
-
         output_dir = self._obj.filesystem.get_output_dir()
         log_dir = output_dir.joinpath("log")
         if not log_dir.exists():

--- a/activitysim/estimation/larch/__init__.py
+++ b/activitysim/estimation/larch/__init__.py
@@ -1,4 +1,7 @@
-import larch
+try:
+    import larch
+except ImportError:
+    larch = None
 
 from .cdap import *
 from .data_maker import *

--- a/activitysim/estimation/larch/cdap.py
+++ b/activitysim/estimation/larch/cdap.py
@@ -7,6 +7,13 @@ import os
 import re
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
+import yaml
+
+from ...abm.models.util import cdap
+from .general import apply_coefficients, explicit_value_parameters
+
 try:
     import larch
 except ImportError:
@@ -18,12 +25,6 @@ else:
     from larch.model.model_group import ModelGroup
     from larch.util import Dict
 
-import numpy as np
-import pandas as pd
-import yaml
-
-from ...abm.models.util import cdap
-from .general import apply_coefficients, explicit_value_parameters
 
 _logger = logging.getLogger(logger_name)
 
@@ -157,7 +158,6 @@ def interact_pattern(n_persons, select_persons, tag):
 
 
 def cdap_interaction_utility(model, n_persons, alts, interaction_coef, coefficients):
-
     person_numbers = list(range(1, n_persons + 1))
 
     matcher = re.compile("coef_[HMN]_.*")

--- a/activitysim/estimation/larch/cdap.py
+++ b/activitysim/estimation/larch/cdap.py
@@ -7,14 +7,20 @@ import os
 import re
 from pathlib import Path
 
-import larch
+try:
+    import larch
+except ImportError:
+    larch = None
+    logger_name = "larch"
+else:
+    from larch import DataFrames, Model, P, X
+    from larch.log import logger_name
+    from larch.model.model_group import ModelGroup
+    from larch.util import Dict
+
 import numpy as np
 import pandas as pd
 import yaml
-from larch import DataFrames, Model, P, X
-from larch.log import logger_name
-from larch.model.model_group import ModelGroup
-from larch.util import Dict
 
 from ...abm.models.util import cdap
 from .general import apply_coefficients, explicit_value_parameters

--- a/activitysim/estimation/larch/general.py
+++ b/activitysim/estimation/larch/general.py
@@ -5,11 +5,18 @@ from typing import Mapping
 
 import numpy as np
 import pandas as pd
-from larch import DataFrames, Model, P, X  # noqa: F401
-from larch.log import logger_name
-from larch.model.abstract_model import AbstractChoiceModel
-from larch.model.tree import NestingTree
-from larch.util import Dict  # noqa: F401
+
+try:
+    import larch
+except ImportError:
+    larch = None
+    logger_name = "larch"
+else:
+    from larch import DataFrames, Model, P, X  # noqa: F401
+    from larch.log import logger_name
+    from larch.model.abstract_model import AbstractChoiceModel
+    from larch.model.tree import NestingTree
+    from larch.util import Dict  # noqa: F401
 
 _logger = logging.getLogger(logger_name)
 

--- a/activitysim/estimation/larch/location_choice.py
+++ b/activitysim/estimation/larch/location_choice.py
@@ -9,8 +9,13 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import yaml
-from larch import DataFrames, Model, P, X
-from larch.util import Dict
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model, P, X
+    from larch.util import Dict
 
 from .general import (
     apply_coefficients,

--- a/activitysim/estimation/larch/location_choice.py
+++ b/activitysim/estimation/larch/location_choice.py
@@ -1,21 +1,14 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
-from typing import Collection
 import pickle
 from datetime import datetime
+from pathlib import Path
+from typing import Collection
 
 import numpy as np
 import pandas as pd
 import yaml
-try:
-    import larch
-except ImportError:
-    larch = None
-else:
-    from larch import DataFrames, Model, P, X
-    from larch.util import Dict
 
 from .general import (
     apply_coefficients,
@@ -26,6 +19,14 @@ from .general import (
     remove_apostrophes,
     str_repr,
 )
+
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model, P, X
+    from larch.util import Dict
 
 
 def size_coefficients_from_spec(size_spec):

--- a/activitysim/estimation/larch/mode_choice.py
+++ b/activitysim/estimation/larch/mode_choice.py
@@ -5,8 +5,13 @@ from typing import Collection
 import numpy as np
 import pandas as pd
 import yaml
-from larch import DataFrames, Model, P, X
-from larch.util import Dict
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model, P, X
+    from larch.util import Dict
 
 from .general import (
     apply_coefficients,

--- a/activitysim/estimation/larch/mode_choice.py
+++ b/activitysim/estimation/larch/mode_choice.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import Collection
@@ -5,13 +7,6 @@ from typing import Collection
 import numpy as np
 import pandas as pd
 import yaml
-try:
-    import larch
-except ImportError:
-    larch = None
-else:
-    from larch import DataFrames, Model, P, X
-    from larch.util import Dict
 
 from .general import (
     apply_coefficients,
@@ -22,6 +17,14 @@ from .general import (
     remove_apostrophes,
 )
 from .simple_simulate import construct_availability, simple_simulate_data
+
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model, P, X
+    from larch.util import Dict
 
 
 def mode_choice_model(

--- a/activitysim/estimation/larch/nonmand_tour_freq.py
+++ b/activitysim/estimation/larch/nonmand_tour_freq.py
@@ -4,9 +4,15 @@ from pathlib import Path
 
 import pandas as pd
 import yaml
-from larch import DataFrames, Model
-from larch.log import logger_name
-from larch.util import Dict
+try:
+    import larch
+except ImportError:
+    larch = None
+    logger_name = "larch"
+else:
+    from larch import DataFrames, Model
+    from larch.log import logger_name
+    from larch.util import Dict
 import pickle
 from datetime import datetime
 

--- a/activitysim/estimation/larch/nonmand_tour_freq.py
+++ b/activitysim/estimation/larch/nonmand_tour_freq.py
@@ -1,9 +1,21 @@
+from __future__ import annotations
+
 import logging
 import os
+import pickle
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
 import yaml
+
+from .general import (
+    apply_coefficients,
+    cv_to_ca,
+    linear_utility_from_spec,
+    remove_apostrophes,
+)
+
 try:
     import larch
 except ImportError:
@@ -13,15 +25,7 @@ else:
     from larch import DataFrames, Model
     from larch.log import logger_name
     from larch.util import Dict
-import pickle
-from datetime import datetime
 
-from .general import (
-    apply_coefficients,
-    cv_to_ca,
-    linear_utility_from_spec,
-    remove_apostrophes,
-)
 
 _logger = logging.getLogger(logger_name)
 

--- a/activitysim/estimation/larch/scheduling.py
+++ b/activitysim/estimation/larch/scheduling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import Collection
@@ -5,13 +7,6 @@ from typing import Collection
 import numpy as np
 import pandas as pd
 import yaml
-try:
-    import larch
-except ImportError:
-    larch = None
-else:
-    from larch import DataFrames, Model, P, X
-    from larch.util import Dict
 
 from .general import (
     apply_coefficients,
@@ -22,6 +17,14 @@ from .general import (
     remove_apostrophes,
     str_repr,
 )
+
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model, P, X
+    from larch.util import Dict
 
 
 def schedule_choice_model(

--- a/activitysim/estimation/larch/scheduling.py
+++ b/activitysim/estimation/larch/scheduling.py
@@ -5,8 +5,13 @@ from typing import Collection
 import numpy as np
 import pandas as pd
 import yaml
-from larch import DataFrames, Model, P, X
-from larch.util import Dict
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model, P, X
+    from larch.util import Dict
 
 from .general import (
     apply_coefficients,

--- a/activitysim/estimation/larch/simple_simulate.py
+++ b/activitysim/estimation/larch/simple_simulate.py
@@ -4,8 +4,13 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import yaml
-from larch import DataFrames, Model
-from larch.util import Dict
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model
+    from larch.util import Dict
 
 from .general import (
     apply_coefficients,

--- a/activitysim/estimation/larch/simple_simulate.py
+++ b/activitysim/estimation/larch/simple_simulate.py
@@ -1,16 +1,11 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import yaml
-try:
-    import larch
-except ImportError:
-    larch = None
-else:
-    from larch import DataFrames, Model
-    from larch.util import Dict
 
 from .general import (
     apply_coefficients,
@@ -18,6 +13,14 @@ from .general import (
     dict_of_linear_utility_from_spec,
     remove_apostrophes,
 )
+
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model
+    from larch.util import Dict
 
 
 def construct_availability(model, chooser_data, alt_codes_to_names):

--- a/activitysim/estimation/larch/stop_frequency.py
+++ b/activitysim/estimation/larch/stop_frequency.py
@@ -4,8 +4,13 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import yaml
-from larch import DataFrames, Model
-from larch.util import Dict
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model
+    from larch.util import Dict
 
 from .general import (
     apply_coefficients,

--- a/activitysim/estimation/larch/stop_frequency.py
+++ b/activitysim/estimation/larch/stop_frequency.py
@@ -1,16 +1,11 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import yaml
-try:
-    import larch
-except ImportError:
-    larch = None
-else:
-    from larch import DataFrames, Model
-    from larch.util import Dict
 
 from .general import (
     apply_coefficients,
@@ -18,6 +13,14 @@ from .general import (
     dict_of_linear_utility_from_spec,
     remove_apostrophes,
 )
+
+try:
+    import larch
+except ImportError:
+    larch = None
+else:
+    from larch import DataFrames, Model
+    from larch.util import Dict
 
 
 def stop_frequency_data(
@@ -148,7 +151,6 @@ def stop_frequency_model(
     models = []
 
     for n in range(len(data.spec)):
-
         coefficients = data.coefficients
         # coef_template = data.coef_template # not used
         spec = data.spec[n]

--- a/activitysim/examples/example_estimation/build_example_data/build_stop_coeffs.py
+++ b/activitysim/examples/example_estimation/build_example_data/build_stop_coeffs.py
@@ -1,5 +1,7 @@
 #  python ~/work/activitysim/activitysim/examples/example_estimation/build_example_data/build_stop_coeffs.py
 
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 
@@ -18,7 +20,6 @@ for what in [
     "othmaint",
     "othdiscr",
 ]:
-
     if FIRST_RUN:
         df = pd.read_csv(f"stop_frequency_{what}.csv", comment="#")
         df.to_csv(f"stop_frequency_backup_{what}.csv", index=False)

--- a/activitysim/examples/optimize_example_data.py
+++ b/activitysim/examples/optimize_example_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import openmatrix
@@ -5,7 +7,6 @@ import pandas as pd
 
 
 def patch_example_sandag_1_zone(example_dir):
-
     cwd = os.getcwd()
     try:
         os.chdir(example_dir)

--- a/activitysim/examples/placeholder_multiple_zone/scripts/three_zone_example_data.py
+++ b/activitysim/examples/placeholder_multiple_zone/scripts/three_zone_example_data.py
@@ -9,6 +9,8 @@
 #
 # This script should work for the full TM1 example as well.
 
+from __future__ import annotations
+
 import os
 import sys
 
@@ -111,7 +113,6 @@ max_distance_for_bike = 5.0
 
 
 with omx.open_file(os.path.join(input_data, "skims.omx")) as ur_skims:
-
     # create df with DIST column
     maz_to_maz = pd.DataFrame(ur_skims["DIST"]).unstack().reset_index()
     maz_to_maz.columns = ["OMAZ", "DMAZ", "DIST"]
@@ -155,9 +156,7 @@ with omx.open_file(
 ) as output_taz_skims_file, omx.open_file(
     os.path.join(output_data, "tap_skims.omx"), "w"
 ) as output_tap_skims_file:
-
     for skim_name in ur_skims.list_matrices():
-
         ur_skim = ur_skims[skim_name][:]
         new_skim = ur_skim[taz_zone_indexes, :][:, taz_zone_indexes]
         # print("skim:", skim_name, ": shape", str(new_skim.shape))

--- a/activitysim/examples/placeholder_multiple_zone/scripts/two_zone_example_data.py
+++ b/activitysim/examples/placeholder_multiple_zone/scripts/two_zone_example_data.py
@@ -9,6 +9,8 @@
 #
 # This script should work for the full TM1 example as well.
 
+from __future__ import annotations
+
 import os
 import sys
 
@@ -107,7 +109,6 @@ with omx.open_file(
 ) as skims_file, omx.open_file(
     os.path.join(output_data, "taz_skims.omx"), "w"
 ) as output_skims_file:
-
     skims = skims_file.list_matrices()
     num_zones = skims_file.shape()[0]
 
@@ -116,7 +117,6 @@ with omx.open_file(
     assert num_zones == len(land_use)
 
     for skim_name in skims_file.list_matrices():
-
         old_skim = skims_file[skim_name][:]
         new_skim = old_skim[new_zone_indexes, :][:, new_zone_indexes]
         output_skims_file[skim_name] = new_skim
@@ -133,7 +133,6 @@ max_distance_for_bike = 5.0
 
 
 with omx.open_file(os.path.join(input_data, "skims.omx")) as skims_file:
-
     # create df with DIST column
     maz_to_maz = pd.DataFrame(np.transpose(skims_file["DIST"])).unstack().reset_index()
     maz_to_maz.columns = ["OMAZ", "DMAZ", "DIST"]

--- a/activitysim/examples/placeholder_multiple_zone/simulation.py
+++ b/activitysim/examples/placeholder_multiple_zone/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/placeholder_multiple_zone/test/simulation.py
+++ b/activitysim/examples/placeholder_multiple_zone/test/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/placeholder_multiple_zone/test/test_multiple_zone.py
+++ b/activitysim/examples/placeholder_multiple_zone/test/test_multiple_zone.py
@@ -44,7 +44,6 @@ def run_test(zone, multiprocess=False):
         return os.path.join(os.path.dirname(__file__), dirname)
 
     def regress(zone):
-
         # regress tours
         regress_tours_df = pd.read_csv(
             test_path(f"regress/final_tours_{zone}_zone.csv")
@@ -157,7 +156,6 @@ EXPECTED_MODELS = [
 
 @test.run_if_exists("reference_pipeline_2_zone.zip")
 def test_multizone_progressive(zone="2"):
-
     zone = str(zone)
 
     import activitysim.abm  # register components
@@ -205,7 +203,6 @@ def test_multizone_progressive(zone="2"):
 
 
 if __name__ == "__main__":
-
     build_data()
     run_test(zone="2", multiprocess=False)
     run_test(zone="2", multiprocess=True)

--- a/activitysim/examples/placeholder_multiple_zone/three_zone_example_data.py
+++ b/activitysim/examples/placeholder_multiple_zone/three_zone_example_data.py
@@ -9,6 +9,8 @@
 #
 # This script should work for the full TM1 example as well.
 
+from __future__ import annotations
+
 import os
 import shutil
 
@@ -108,7 +110,6 @@ max_distance_for_bike = 5.0
 
 
 with omx.open_file(os.path.join(input_data, "skims.omx")) as ur_skims:
-
     # create df with DIST column
     maz_to_maz = pd.DataFrame(ur_skims["DIST"]).unstack().reset_index()
     maz_to_maz.columns = ["OMAZ", "DMAZ", "DIST"]
@@ -149,9 +150,7 @@ with omx.open_file(
 ) as output_taz_skims_file, omx.open_file(
     os.path.join(output_data, "tap_skims.omx"), "w"
 ) as output_tap_skims_file:
-
     for skim_name in ur_skims.list_matrices():
-
         ur_skim = ur_skims[skim_name][:]
         new_skim = ur_skim[taz_zone_indexes, :][:, taz_zone_indexes]
         # print("skim:", skim_name, ": shape", str(new_skim.shape))

--- a/activitysim/examples/placeholder_multiple_zone/two_zone_example_data.py
+++ b/activitysim/examples/placeholder_multiple_zone/two_zone_example_data.py
@@ -9,6 +9,8 @@
 #
 # This script should work for the full TM1 example as well.
 
+from __future__ import annotations
+
 import os
 import shutil
 
@@ -104,7 +106,6 @@ with omx.open_file(
 ) as skims_file, omx.open_file(
     os.path.join(output_data, "taz_skims.omx"), "w"
 ) as output_skims_file:
-
     skims = skims_file.list_matrices()
     num_zones = skims_file.shape()[0]
 
@@ -113,7 +114,6 @@ with omx.open_file(
     assert num_zones == len(land_use)
 
     for skim_name in skims_file.list_matrices():
-
         old_skim = skims_file[skim_name][:]
         new_skim = old_skim[new_zone_indexes, :][:, new_zone_indexes]
         output_skims_file[skim_name] = new_skim
@@ -129,7 +129,6 @@ max_distance_for_bike = 5.0
 
 
 with omx.open_file(os.path.join(input_data, "skims.omx")) as skims_file:
-
     # create df with DIST column
     maz_to_maz = pd.DataFrame(np.transpose(skims_file["DIST"])).unstack().reset_index()
     maz_to_maz.columns = ["OMAZ", "DMAZ", "DIST"]

--- a/activitysim/examples/placeholder_psrc/scripts/integrity.py
+++ b/activitysim/examples/placeholder_psrc/scripts/integrity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -60,7 +62,6 @@ def to_csv(df, file_name):
 
 
 def report_baddies(df, tag, fatal=False):
-
     if len(df) > 0:
         print(f"\n### OOPS ### {len(df)} {tag}\n")
 

--- a/activitysim/examples/placeholder_psrc/scripts/psrc_crop.py
+++ b/activitysim/examples/placeholder_psrc/scripts/psrc_crop.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -99,7 +101,6 @@ print(f"output_dir {output_dir} taz_min {taz_min} taz_max {taz_max}")
 
 
 if check_geography:
-
     # ######## check for orphan_households not in any maz in land_use
     land_use = read_csv("land_use.csv")
     land_use = land_use[["MAZ", "TAZ"]]  # King County
@@ -264,7 +265,6 @@ for omx_file in omx_out:
 
 iskim = 0
 for mat_name in omx_in.list_matrices():
-
     # make sure we have a vanilla numpy array, not a CArray
     m = np.asanyarray(omx_in[mat_name]).astype(skim_data_type)
     m = m[tazs_indexes, :][:, tazs_indexes]

--- a/activitysim/examples/placeholder_psrc/test/simulation.py
+++ b/activitysim/examples/placeholder_psrc/test/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/placeholder_sandag/scripts/sandag_crop_1_zone.py
+++ b/activitysim/examples/placeholder_sandag/scripts/sandag_crop_1_zone.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -84,7 +86,6 @@ def to_csv(df, file_name):
 
 
 if check_geography:
-
     # ######## check for orphan_households not in any taz in land_use
     land_use = read_csv("land_use.csv")
 
@@ -159,7 +160,6 @@ for omx_file in omx_out:
 
 iskim = 0
 for mat_name in omx_in.list_matrices():
-
     # make sure we have a vanilla numpy array, not a CArray
     m = np.asanyarray(omx_in[mat_name]).astype(skim_data_type)
     m = m[zone_indexes, :][:, zone_indexes]

--- a/activitysim/examples/placeholder_sandag/scripts/sandag_crop_2_zone.py
+++ b/activitysim/examples/placeholder_sandag/scripts/sandag_crop_2_zone.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -91,7 +93,6 @@ print(f"output_dir {output_dir} maz_min {maz_min} maz_max {maz_max}")
 
 
 if check_geography:
-
     # ######## check for orphan_households not in any maz in land_use
     land_use = read_csv("land_use.csv")
     land_use = land_use[["MAZ", "TAZ"]]  # King County
@@ -255,7 +256,6 @@ for omx_file in omx_out:
 
 iskim = 0
 for mat_name in omx_in.list_matrices():
-
     # make sure we have a vanilla numpy array, not a CArray
     m = np.asanyarray(omx_in[mat_name]).astype(skim_data_type)
     m = m[tazs_indexes, :][:, tazs_indexes]

--- a/activitysim/examples/placeholder_sandag/scripts/sandag_crop_3_zone.py
+++ b/activitysim/examples/placeholder_sandag/scripts/sandag_crop_3_zone.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -83,7 +85,6 @@ def to_csv(df, file_name):
 
 
 def crop_omx(omx_file_name, zones, num_outfiles=1):
-
     skim_data_type = np.float32
 
     omx_in = omx.open_file(input_path(f"{omx_file_name}.omx"))
@@ -139,7 +140,6 @@ TAZ = "taz.csv"
 
 
 if check_geography:
-
     # ######## check for orphan_households not in any maz in land_use
     land_use = read_csv(LAND_USE)
     land_use = land_use[["MAZ", "TAZ"]]

--- a/activitysim/examples/placeholder_sandag/test/simulation.py
+++ b/activitysim/examples/placeholder_sandag/test/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/placeholder_sandag/test/test_sandag.py
+++ b/activitysim/examples/placeholder_sandag/test/test_sandag.py
@@ -47,7 +47,6 @@ def run_test(zone, multiprocess=False, sharrow=False, recode=True):
         return os.path.join(os.path.dirname(__file__), dirname)
 
     def regress(zone):
-
         # ## regress tours
         if sharrow and os.path.isfile(
             test_path(f"regress/final_{zone}_zone_tours_sh.csv")
@@ -315,7 +314,6 @@ def test_3_zone_progressive():
 
 
 if __name__ == "__main__":
-
     # call each test explicitly so we get a pass/fail for each
     build_data()
     run_test(zone="1", multiprocess=False)

--- a/activitysim/examples/production_semcog/scripts/semcog_crop.py
+++ b/activitysim/examples/production_semcog/scripts/semcog_crop.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -94,7 +96,6 @@ def to_csv(df, file_name):
 
 
 if check_geography:
-
     # ######## check for orphan_households not in any maz in land_use
     land_use = read_csv("land_use.csv")
 
@@ -199,7 +200,6 @@ for omx_file in omx_out:
 
 iskim = 0
 for mat_name in omx_in.list_matrices():
-
     # make sure we have a vanilla numpy array, not a CArray
     m = np.asanyarray(omx_in[mat_name]).astype(skim_data_type)
     m = m[zone_indexes, :][:, zone_indexes]

--- a/activitysim/examples/production_semcog/simulation.py
+++ b/activitysim/examples/production_semcog/simulation.py
@@ -1,15 +1,16 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
-from activitysim.cli.run import add_run_args, run
-
 import extensions
 
-if __name__ == "__main__":
+from activitysim.cli.run import add_run_args, run
 
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_arc/scripts/arc_crop.py
+++ b/activitysim/examples/prototype_arc/scripts/arc_crop.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -92,7 +94,6 @@ def to_csv(df, file_name):
 
 
 if check_geography:
-
     # ######## check for orphan_households not in any maz in land_use
     land_use = read_csv("land_use.csv")
 
@@ -170,7 +171,6 @@ for omx_file in omx_out:
 
 iskim = 0
 for mat_name in omx_in.list_matrices():
-
     # make sure we have a vanilla numpy array, not a CArray
     m = np.asanyarray(omx_in[mat_name]).astype(skim_data_type)
     m = m[zone_indexes, :][:, zone_indexes]

--- a/activitysim/examples/prototype_arc/simulation.py
+++ b/activitysim/examples/prototype_arc/simulation.py
@@ -4,13 +4,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_arc/test/simulation.py
+++ b/activitysim/examples/prototype_arc/test/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_arc/test/test_arc.py
+++ b/activitysim/examples/prototype_arc/test/test_arc.py
@@ -91,7 +91,6 @@ def test_arc_sharrow():
 
 
 if __name__ == "__main__":
-
     _test_arc()
     _test_arc(recode=True)
     _test_arc(sharrow=True)

--- a/activitysim/examples/prototype_marin/scripts/marin_crop.py
+++ b/activitysim/examples/prototype_marin/scripts/marin_crop.py
@@ -1,6 +1,8 @@
 # crop marin tvpb example data processing to one county
 # Ben Stabler, ben.stabler@rsginc.com, 09/17/20
 
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -95,7 +97,6 @@ ACCESSIBILITY = "access.csv"
 WORK_TOURS = "work_tours.csv"
 
 if check_geography:
-
     # ######## check for orphan_households not in any maz in land_use
     land_use = read_csv(LAND_USE)
     land_use = land_use[["MAZ", "TAZ"]]

--- a/activitysim/examples/prototype_marin/test/simulation.py
+++ b/activitysim/examples/prototype_marin/test/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_mtc/simulation.py
+++ b/activitysim/examples/prototype_mtc/simulation.py
@@ -1,6 +1,8 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
@@ -8,7 +10,6 @@ from activitysim import abm  # register injectables
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_mtc/test/simulation.py
+++ b/activitysim/examples/prototype_mtc/test/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_mtc_extended/sampling_scenarios.py
+++ b/activitysim/examples/prototype_mtc_extended/sampling_scenarios.py
@@ -95,7 +95,6 @@ def make_scene_name(it, params):
 
 
 def copy_output(scene_name, model_settings):
-
     scene_dir_name = os.path.join("scenarios_output", scene_name)
 
     if os.path.exists(extended_path(scene_dir_name)):

--- a/activitysim/examples/prototype_mtc_extended/test/simulation.py
+++ b/activitysim/examples/prototype_mtc_extended/test/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_mwcog/scripts/mwcog_crop.py
+++ b/activitysim/examples/prototype_mwcog/scripts/mwcog_crop.py
@@ -1,11 +1,14 @@
 # crop marin tvpb example data processing to one county
 # Ben Stabler, ben.stabler@rsginc.com, 09/17/20
 
-import os
-import pandas as pd
-import openmatrix as omx
+from __future__ import annotations
+
 import argparse
+import os
+
 import numpy as np
+import openmatrix as omx
+import pandas as pd
 
 MAZ_OFFSET = 0
 
@@ -259,7 +262,6 @@ SUBZONE = "subzoneData.csv"
 
 
 if check_geography:
-
     # ######## check for orphan_households not in any maz in land_use
     land_use = read_csv(LAND_USE)
     land_use = land_use[["maz", "taz"]]

--- a/activitysim/examples/prototype_mwcog/simulation.py
+++ b/activitysim/examples/prototype_mwcog/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/examples/prototype_mwcog/test/test_mwcog.py
+++ b/activitysim/examples/prototype_mwcog/test/test_mwcog.py
@@ -73,5 +73,4 @@ def test_mwcog_sharrow():
 
 
 if __name__ == "__main__":
-
     test_mwcog()

--- a/activitysim/examples/prototype_sandag_xborder/extensions/reassign_tour_purpose.py
+++ b/activitysim/examples/prototype_sandag_xborder/extensions/reassign_tour_purpose.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 @workflow.step
 def reassign_tour_purpose_by_poe(state: workflow.State, tours: pd.DataFrame) -> None:
-
     """
     Simulates tour purpose choices after tour origin has been assigned. This
     is useful when the original tour purposes are assigned randomly

--- a/activitysim/examples/prototype_sandag_xborder/scripts/sandag_crop_3_zone.py
+++ b/activitysim/examples/prototype_sandag_xborder/scripts/sandag_crop_3_zone.py
@@ -2,6 +2,8 @@
 # crop marin tvpb example data processing to one county
 # Ben Stabler, ben.stabler@rsginc.com, 09/17/20
 
+from __future__ import annotations
+
 import argparse
 import glob
 import os
@@ -83,7 +85,6 @@ def to_csv(df, file_name):
 
 
 def crop_omx(omx_file_name, zones, num_outfiles=1):
-
     skim_data_type = np.float32
 
     omx_in = omx.open_file(input_path(f"{omx_file_name}.omx"))

--- a/activitysim/examples/prototype_sandag_xborder/simulation.py
+++ b/activitysim/examples/prototype_sandag_xborder/simulation.py
@@ -1,6 +1,8 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import os
 import sys
@@ -10,7 +12,6 @@ import extensions
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/activitysim/workflows/steps/chunk_sizing.py
+++ b/activitysim/workflows/steps/chunk_sizing.py
@@ -28,7 +28,6 @@ def chunk_sizing(
 
     # if chunk size is set explicitly, use it without regard to other settings
     if chunk_size is None:
-
         if chunk_size_pct_of_available is not None:
             if chunk_size_pct_of_available > 1:
                 chunk_size_pct_of_available /= 100

--- a/activitysim/workflows/steps/contrast/composite_log.py
+++ b/activitysim/workflows/steps/contrast/composite_log.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pandas as pd
@@ -26,7 +28,6 @@ def composite_log(
     archive_dir,
     compares=("compile", "sharrow", "legacy", "reference"),
 ) -> dict:
-
     reset_progress_step(description="composite timing and memory logs")
 
     timings = {}

--- a/activitysim/workflows/steps/contrast/runtime.py
+++ b/activitysim/workflows/steps/contrast/runtime.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import altair as alt
@@ -65,7 +67,6 @@ def contrast_runtime(
     )
 
     if len(include_runs) == 1:
-
         result = c.mark_bar(size=6,).encode(
             x=alt.X("seconds:Q", stack=None),
             y=alt.Y("model_name", type="nominal", sort=None),
@@ -79,7 +80,6 @@ def contrast_runtime(
         )
 
     elif len(include_runs) == 2:
-
         result = c.mark_bar(yOffset=-3, size=6,).transform_filter(
             (alt.datum.source == relabel_source(include_runs[0]))
         ).encode(

--- a/activitysim/workflows/steps/contrast/transform_data.py
+++ b/activitysim/workflows/steps/contrast/transform_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import numpy as np
@@ -22,7 +24,6 @@ def transform_data(
     censor=None,
     eval=None,
 ) -> dict:
-
     if qcut is None and cut is None and clip is None and censor is None:
         raise ValueError("must give at least one of {cut, qcut, clip, censor}")
 

--- a/activitysim/workflows/steps/main.py
+++ b/activitysim/workflows/steps/main.py
@@ -21,7 +21,6 @@ def get_pipeline_definition(pipeline_name, parent):
         with open(workflow_file) as yaml_file:
             return pypyr.yaml.get_pipeline_yaml(yaml_file)
     else:
-
         return get_pipeline_definition(pipeline_name, parent)
 
 
@@ -53,7 +52,6 @@ def main(args):
         os.environ["NO_RICH"] = "1"
 
     with get_progress():
-
         try:
             import pypyr.log.logger
             import pypyr.pipelinerunner

--- a/activitysim/workflows/steps/memory_stress_test.py
+++ b/activitysim/workflows/steps/memory_stress_test.py
@@ -25,7 +25,6 @@ def ping_mem(pid=None):
 
 @workstep(updates_context=True)
 def memory_stress_test(n=37):
-
     logging.critical(f"ping_mem = {ping_mem()}")
     big = np.arange(int(2 ** float(n) / 8), dtype=np.float64)
     big *= 2.0

--- a/activitysim/workflows/steps/progression.py
+++ b/activitysim/workflows/steps/progression.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 from datetime import timedelta
@@ -26,12 +28,10 @@ class DummyProgress:
 dummy_progress = DummyProgress()
 
 try:
-
     from rich.panel import Panel
     from rich.progress import Progress, ProgressColumn, Text
 
 except ImportError:
-
     # allow printing in color on windows terminal
     if os.name == "nt":
         import ctypes

--- a/activitysim/workflows/steps/reporting/save_report.py
+++ b/activitysim/workflows/steps/reporting/save_report.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import shutil
@@ -22,7 +24,6 @@ def save_report(
     toc_color="forest",
     copy_filename=None,
 ):
-
     bootstrap_font_family = (
         'font-family: -apple-system, "system-ui", "Segoe UI",'
         ' "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",'

--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -40,7 +40,7 @@ dependencies:
 - numpydoc
 - openmatrix = 0.3.*
 - orca = 1.8
-- pandas = 1.4.*
+- pandas = 2.2.*
 - pandera >= 0.15, <0.18.1
 - platformdirs = 3.2.*
 - pre-commit

--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -40,7 +40,7 @@ dependencies:
 - numpydoc
 - openmatrix = 0.3.*
 - orca = 1.8
-- pandas = 2.2.*
+- pandas = 1.4.*
 - pandera >= 0.15, <0.18.1
 - platformdirs = 3.2.*
 - pre-commit

--- a/conda-environments/docbuild.yml
+++ b/conda-environments/docbuild.yml
@@ -32,7 +32,7 @@ dependencies:
 - numpy >= 1.16.1, <2
 - numpydoc
 - openmatrix >= 0.3.4.1
-- pandas >= 1.1.0,<2
+- pandas = 2.2.*
 - pandera >= 0.15, <0.18.1
 - platformdirs
 - psutil >= 4.1

--- a/conda-environments/docbuild.yml
+++ b/conda-environments/docbuild.yml
@@ -32,12 +32,11 @@ dependencies:
 - numpy >= 1.16.1, <2
 - numpydoc
 - openmatrix >= 0.3.4.1
-- orca >= 1.6
 - pandas >= 1.1.0,<2
 - pandera >= 0.15, <0.18.1
 - platformdirs
 - psutil >= 4.1
-- pyarrow >= 2.0
+- pyarrow >= 2.0,<19
 - pydantic = 2.6.*
 - pypyr >= 5.3
 - pytables >=3.7

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,7 +236,7 @@ intersphinx_mapping = {
     "pandas": ("http://pandas.pydata.org/pandas-docs/stable", None),
     "xarray": ("https://docs.xarray.dev/en/stable", None),
     "pyarrow": ("https://arrow.apache.org/docs", None),
-    "numba": ("https://numba.pydata.org/numba-doc/latest", None),
+    "numba": ("https://numba.readthedocs.io/en/latest/", None),
     "psutil": ("https://psutil.readthedocs.io/en/latest", None),
 }
 

--- a/other_resources/scripts/build_omx.py
+++ b/other_resources/scripts/build_omx.py
@@ -3,6 +3,8 @@
 # See full license in LICENSE.txt.
 # run from the mtc tm1 skims folder
 
+from __future__ import annotations
+
 import os
 
 import openmatrix as omx
@@ -10,7 +12,6 @@ import pandas as pd
 
 
 def read_manifest(manifest_file_name):
-
     column_map = {
         "Token": "skim_key1",
         "TimePeriod": "skim_key2",
@@ -29,9 +30,7 @@ def read_manifest(manifest_file_name):
 
 
 def omx_getMatrix(omx_file_name, omx_key):
-
     with omx.open_file(omx_file_name, "r") as omx_file:
-
         if omx_key not in omx_file.list_matrices():
             print(
                 "Source matrix with key '%s' not found in file '%s"
@@ -62,11 +61,9 @@ manifest_file_name = os.path.join(manifest_dir, "skim_manifest.csv")
 dest_file_name = os.path.join(dest_data_dir, "skims.omx")
 
 with omx.open_file(dest_file_name, "a") as dest_omx:
-
     manifest = read_manifest(manifest_file_name)
 
     for row in manifest.itertuples(index=True):
-
         source_file_name = os.path.join(source_data_dir, row.source_file_name)
 
         if row.skim_key2:
@@ -83,7 +80,6 @@ with omx.open_file(dest_file_name, "a") as dest_omx:
             )
         )
         with omx.open_file(source_file_name, "r") as source_omx:
-
             if row.source_key not in source_omx.list_matrices():
                 print(
                     "Source matrix with key '%s' not found in file '%s"

--- a/other_resources/scripts/create_sf_example.py
+++ b/other_resources/scripts/create_sf_example.py
@@ -1,6 +1,8 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import os
 import sys
 
@@ -23,7 +25,6 @@ dest_data_dir = "/Users/jeff.doyle/work/activitysim-data"
 
 
 def create_subset(dest_store, dest_skims, maxZone, households_sample_size=0):
-
     dest_store_path = os.path.join(dest_data_dir, dest_store)
     dest_skims_path = os.path.join(dest_data_dir, dest_skims)
 

--- a/other_resources/scripts/make_pipeline_output.py
+++ b/other_resources/scripts/make_pipeline_output.py
@@ -2,6 +2,8 @@
 # Ben Stabler, ben.stabler@rsginc.com, 06/06/18
 # C:\projects\development\activitysim\example>python ../scripts/make_pipeline_output.py
 
+from __future__ import annotations
+
 import pandas as pd
 
 pipeline_filename = "output\\pipeline.h5"
@@ -26,7 +28,6 @@ p_tables = p_tables.sort_values(by=["table", "timestamp"])
 # TABLE, FIELD, DTYPE, CREATOR, NCOL, NROW
 tables_fields = dict()
 for i in range(len(p_tables)):
-
     cur_table = p_tables["table"].iloc[i]
     cur_cp = p_tables["cp"].iloc[i]
 

--- a/other_resources/scripts/omx32.py
+++ b/other_resources/scripts/omx32.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -37,7 +39,6 @@ for mapping_name in omx_in.listMappings():
 
 
 for mat_name in omx_in.list_matrices():
-
     # make sure we have a vanilla numpy array, not a CArray
     m = np.asanyarray(omx_in[mat_name])
     print(f"{mat_name} {m.shape} {type(m[0,0])}")

--- a/other_resources/scripts/simulation.py
+++ b/other_resources/scripts/simulation.py
@@ -1,6 +1,8 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import logging
 import sys
 
@@ -13,7 +15,6 @@ logger = logging.getLogger("activitysim")
 
 
 def cleanup_output_files(state: workflow.State):
-
     active_log_files = [
         h.baseFilename
         for h in logger.root.handlers
@@ -30,7 +31,6 @@ def cleanup_output_files(state: workflow.State):
 
 
 def run(run_list, injectables=None):
-
     if run_list["multiprocess"]:
         logger.info("run multiprocess simulation")
         mp_tasks.run_multiprocess(run_list, injectables)
@@ -42,7 +42,6 @@ def run(run_list, injectables=None):
 
 
 def log_settings(injectables):
-
     settings = [
         "households_sample_size",
         "chunk_size",
@@ -59,7 +58,6 @@ def log_settings(injectables):
 
 
 if __name__ == "__main__":
-
     state.add_injectable("data_dir", "data")
     state.add_injectable("configs_dir", "configs")
 

--- a/other_resources/scripts/verify_results.py
+++ b/other_resources/scripts/verify_results.py
@@ -4,6 +4,8 @@
 # C:\projects\activitysim\verification>python compare_results.py
 #############################################################
 
+from __future__ import annotations
+
 import openmatrix as omx
 import pandas as pd
 
@@ -138,7 +140,6 @@ asim_access.to_csv("outputs/asim_access.csv", na_rep=0)
 # work and school location
 
 if process_sp:
-
     if process_tm1:
         tm1_markets = [
             "work_low",

--- a/test/cdap/test_cdap.py
+++ b/test/cdap/test_cdap.py
@@ -18,6 +18,7 @@ from activitysim.core.util import read_csv, to_csv
 
 logger = logging.getLogger(__name__)
 
+
 # Used by conftest.py initialize_pipeline method
 @pytest.fixture(scope="module")
 def module() -> str:

--- a/test/joint_tours/test_joint_tours.py
+++ b/test/joint_tours/test_joint_tours.py
@@ -16,6 +16,7 @@ from activitysim.core.util import read_csv, to_csv
 
 logger = logging.getLogger(__name__)
 
+
 # Used by conftest.py initialize_pipeline method
 @pytest.fixture(scope="module")
 def module() -> str:
@@ -81,7 +82,6 @@ def test_prepare_input_pipeline(initialize_pipeline: workflow.State, caplog):
 
 
 def test_joint_tours_frequency_composition(reconnect_pipeline: workflow.State, caplog):
-
     caplog.set_level(logging.INFO)
 
     state = reconnect_pipeline
@@ -96,7 +96,6 @@ def test_joint_tours_frequency_composition(reconnect_pipeline: workflow.State, c
 
 
 def test_joint_tours_participation(reconnect_pipeline: workflow.State, caplog):
-
     caplog.set_level(logging.INFO)
 
     state = reconnect_pipeline

--- a/test/non_mandatory_tour_frequency/test_non_mandatory_tour_frequency.py
+++ b/test/non_mandatory_tour_frequency/test_non_mandatory_tour_frequency.py
@@ -18,6 +18,7 @@ from activitysim.core.util import read_csv, to_csv
 
 logger = logging.getLogger(__name__)
 
+
 # Used by conftest.py initialize_pipeline method
 @pytest.fixture(scope="module")
 def module() -> str:

--- a/test/parking_location/test_parking_location.py
+++ b/test/parking_location/test_parking_location.py
@@ -19,6 +19,7 @@ from activitysim.core.util import read_csv, to_csv
 
 logger = logging.getLogger(__name__)
 
+
 # Used by conftest.py initialize_pipeline method
 @pytest.fixture(scope="module")
 def module() -> str:

--- a/test/random_seed/simulation.py
+++ b/test/random_seed/simulation.py
@@ -1,13 +1,14 @@
 # ActivitySim
 # See full license in LICENSE.txt.
 
+from __future__ import annotations
+
 import argparse
 import sys
 
 from activitysim.cli.run import add_run_args, run
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     add_run_args(parser)
     args = parser.parse_args()

--- a/test/random_seed/test_random_seed.py
+++ b/test/random_seed/test_random_seed.py
@@ -25,7 +25,6 @@ def update_settings(settings_file, key, value):
 
 
 def run_test_random_seed():
-
     steps_to_run = [
         "initialize_landuse",
         "initialize_households",
@@ -86,7 +85,6 @@ def run_test_random_seed():
     # running prototype mtc model through workplace_location with 3 random seed settings, 0, 1, None, and undefined.
     # final_persons.csv is compared to ensure the same setting returns the same variables and a different setting returns something different.
     for name, seed in runs:
-
         run_args = [
             "-c",
             test_path("configs_random_seed__{}".format(seed)),


### PR DESCRIPTION
This pull request touches a lot of files, mostly for application of `black` and `isort`.

The substantive changes include building the *documentation* against pandas version 2, as some of the doc tool dependencies now require that; the documentation builder doesn't actually run ActivitySim models so this has no impact on the code itself.