### PR TITLE
Update version and name to 1.5 in switcher.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="Refresh" content="0; url='v1.4.0'" />
+<meta http-equiv="Refresh" content="0; url='v1.5.0'" />

--- a/switcher.json
+++ b/switcher.json
@@ -5,7 +5,12 @@
         "url": "https://activitysim.github.io/activitysim/develop/index.html"
     },
     {
-        "name": "1.4 (Latest)",
+        "name": "1.5 (Latest)",
+        "version": "1.5.0",
+        "url": "https://activitysim.github.io/activitysim/v1.5.0/index.html"
+    },
+    {
+        "name": "1.4",
         "version": "1.4.0",
         "url": "https://activitysim.github.io/activitysim/v1.4.0/index.html"
     },


### PR DESCRIPTION
This pull request updates the documentation version switcher configuration to reflect the release of version 1.5.0. The latest version is now set to 1.5, and the previous latest (1.4) is listed as a separate entry.

Documentation versioning update:

* Updated the `switcher.json` file to set "1.5 (Latest)" as the latest version, added its version number and URL, and moved "1.4" to a separate entry with its version and URL.