### PR TITLE
Fix for `explicit_chunk` with non fractional values

### DIFF
--- a/activitysim/core/chunk.py
+++ b/activitysim/core/chunk.py
@@ -1400,8 +1400,13 @@ def adaptive_chunked_choosers_and_alts(
     )
     rows_per_chunk, estimated_number_of_chunks = chunk_sizer.initial_rows_per_chunk()
     assert (rows_per_chunk > 0) and (
-        (rows_per_chunk <= num_choosers) & (estimated_number_of_chunks > 1)
-    ) | ((rows_per_chunk >= num_choosers) & (estimated_number_of_chunks == 1))
+        (rows_per_chunk <= num_choosers)
+        or (
+            (rows_per_chunk >= num_choosers)
+            and (estimated_number_of_chunks == 1)
+            and (state.settings.chunk_training_mode == MODE_EXPLICIT)
+        )
+    )
 
     # alt chunks boundaries are where index changes
     alt_ids = alternatives.index.values


### PR DESCRIPTION
This PR addresses #1002.

- [x] When the specified `explicit_chunk` is larger than the number of choosers, the model runs in one chunk, equivalent to chunkless. [[1](https://github.com/ActivitySim/activitysim/pull/1003/files#diff-b0056f4974ba26d83d2171207813c1d925a36b3512649ff8b4b1d4a2af213d25R1402-R1409)]
- [x] When running multiprocess, the model divides `explicit_chunk` by `num_processes`, so users don't need to change `explicit_chunk` when they change `num_processes`. In this case, the value of `explicit_chunk` represents the total number of choosers running concurrently across all processes, within a machine's memory limit. [[2](https://github.com/ActivitySim/activitysim/compare/main...wsp-sag:activitysim:explicit-chunk-quick-fix?expand=1#diff-b0056f4974ba26d83d2171207813c1d925a36b3512649ff8b4b1d4a2af213d25R1380-R1383)][[3](https://github.com/ActivitySim/activitysim/compare/main...wsp-sag:activitysim:explicit-chunk-quick-fix?expand=1#diff-b0056f4974ba26d83d2171207813c1d925a36b3512649ff8b4b1d4a2af213d25R1389)]