### PR TITLE
fix(estimation): correct the participant_num assignment logic for estimation mode in joint tour participation 

### DIFF
--- a/activitysim/abm/models/joint_tour_frequency.py
+++ b/activitysim/abm/models/joint_tour_frequency.py
@@ -137,7 +137,15 @@ def joint_tour_frequency(
     # - but we don't know the tour participants yet
     # - so we arbitrarily choose the first person in the household
     # - to be point person for the purpose of generating an index and setting origin
-    temp_point_persons = persons.loc[persons.PNUM == 1]
+    if "PNUM" in persons.columns:
+        temp_point_persons = persons.loc[persons.PNUM == 1]
+    else:
+        # if PNUM is not available, we can still get the first person in the household
+        temp_point_persons = (
+            persons.sort_index()  # ensure stable ordering
+            .groupby("household_id", as_index=False)
+            .first()
+        )
     temp_point_persons["person_id"] = temp_point_persons.index
     temp_point_persons = temp_point_persons.set_index("household_id")
     temp_point_persons = temp_point_persons[["person_id", "home_zone_id"]]

--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -457,7 +457,9 @@ def joint_tour_participation(
         # leader, so the joint tour in the tour table will be associated with the tour
         # leader's person_id. We merge participant_num from survey data using the
         # participant_id as the join key to ensure the correct tour leader is identified.
-        participants["participant_num"] = survey_participants_df.reindex(participants.index)["participant_num"]
+        participants["participant_num"] = survey_participants_df.reindex(
+            participants.index
+        )["participant_num"]
     else:
         # assign participant_num
         # FIXME do we want something smarter than the participant with the lowest person_id?

--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -451,14 +451,22 @@ def joint_tour_participation(
     PARTICIPANT_COLS = ["tour_id", "household_id", "person_id"]
     participants = candidates[participate][PARTICIPANT_COLS].copy()
 
-    # assign participant_num
-    # FIXME do we want something smarter than the participant with the lowest person_id?
-    participants["participant_num"] = (
-        participants.sort_values(by=["tour_id", "person_id"])
-        .groupby("tour_id")
-        .cumcount()
-        + 1
-    )
+    if estimator:
+        # In estimation mode, use participant_num from survey data to preserve consistency
+        # with the original survey data. ActivitySim treats participant_num=1 as the tour
+        # leader, so the joint tour in the tour table will be associated with the tour
+        # leader's person_id. We merge participant_num from survey data using the
+        # participant_id as the join key to ensure the correct tour leader is identified.
+        participants["participant_num"] = survey_participants_df.reindex(participants.index)["participant_num"]
+    else:
+        # assign participant_num
+        # FIXME do we want something smarter than the participant with the lowest person_id?
+        participants["participant_num"] = (
+            participants.sort_values(by=["tour_id", "person_id"])
+            .groupby("tour_id")
+            .cumcount()
+            + 1
+        )
 
     state.add_table("joint_tour_participants", participants)
 


### PR DESCRIPTION
This PR fixes two related issues in the joint-tour code paths:

## `joint_tour_participation.py` (8f13299)
**Problem**: In estimation mode, the code could re-assign participant_num rather than using the original survey participant_num, which could change the identity of the tour leader (ActivitySim treats participant_num == 1 as the tour leader). This broke association of the joint tour with the correct person.

**Fix**: When running in estimation mode, we now merge participant_num from the survey's joint_tour_participants table by participant_id so the original participant numbering (and the tour leader) is preserved.

## `joint_tour_frequency.py` (2e7629e6)
**Problem**: The code assumed a PNUM column existed; where PNUM was missing, code could fail or behave unpredictably.

**Fix**: If PNUM is missing, the code now selects the first person in the household to act as the PNUM (keeps behavior deterministic and prevents failures).

cc: @dhensle 
