### PR TITLE
Patch sharrow sandag

### DIFF
--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -1515,7 +1515,8 @@ def run_trip_destination(
                     )
                 except KeyError as err:
                     if err.args[0] == "purpose_index_num":
-                        logger.error("""
+                        logger.error(
+                            """
                         
                         When using the trip destination model with sharrow, it is necessary
                         to set a value for `purpose_index_num` in the trip destination 
@@ -1527,7 +1528,8 @@ def run_trip_destination(
                         "size_terms.get_cols(df.purpose)" unless some unusual transform of 
                         size terms has been employed.
                         
-                        """)
+                        """
+                        )
                     raise
 
                 choices_list.append(choices)

--- a/activitysim/abm/models/trip_destination.py
+++ b/activitysim/abm/models/trip_destination.py
@@ -1517,7 +1517,7 @@ def run_trip_destination(
                     if err.args[0] == "purpose_index_num":
                         logger.error(
                             """
-                        
+
                         When using the trip destination model with sharrow, it is necessary
                         to set a value for `purpose_index_num` in the trip destination 
                         annotate trips preprocessor.  This allows for an optimized compiled 
@@ -1527,7 +1527,7 @@ def run_trip_destination(
                         column is zero).  The preprocessor expression most likely needs to be
                         "size_terms.get_cols(df.purpose)" unless some unusual transform of 
                         size terms has been employed.
-                        
+
                         """
                         )
                     raise

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -988,7 +988,7 @@ def eval_variables(
 #     return utilities
 
 
-def set_skim_wrapper_targets(df, skims):
+def set_skim_wrapper_targets(df, skims, allow_partial_success: bool = True):
     """
     Add the dataframe to the SkimWrapper object so that it can be dereferenced
     using the parameters of the skims object.
@@ -1015,13 +1015,21 @@ def set_skim_wrapper_targets(df, skims):
         if isinstance(skims, dict)
         else [skims]
     )
+    problems = []
 
     # assume any object in skims can be treated as a skim
     for skim in skims:
         try:
             skim.set_df(df)
-        except AttributeError:
-            pass
+        except (AttributeError, AssertionError) as e:
+            problems.append(e)
+            if not allow_partial_success:
+                raise
+
+    if problems:
+        # if problems were discovered, log them as warnings
+        for problem in problems:
+            logger.warning(str(problem))
 
 
 #

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -1021,7 +1021,17 @@ def set_skim_wrapper_targets(df, skims, allow_partial_success: bool = True):
     for skim in skims:
         try:
             skim.set_df(df)
-        except (AttributeError, AssertionError) as e:
+        except AttributeError:
+            # sometimes when passed as a dict, the skims have a few keys given as
+            # settings or constants, which are not actually "skim" objects and have
+            # no `set_df` attribute.  This is fine and we just let them pass.
+            pass
+        except AssertionError as e:
+            # An assertion error will get triggered if the columns of `df` are
+            # missing one of the required keys needed to look up values in the
+            # skims.  This may not be a problem, if this particular set of skims
+            # is not actually used in this model component.  So we'll warn about
+            # it but usually not raise a showstopping error.
             problems.append(e)
             if not allow_partial_success:
                 raise

--- a/activitysim/core/simulate.py
+++ b/activitysim/core/simulate.py
@@ -1006,6 +1006,11 @@ def set_skim_wrapper_targets(df, skims, allow_partial_success: bool = True):
         dataframe that comes back from interacting choosers with
         alternatives.  See the skims module for more documentation on how
         the skims object is intended to be used.
+    allow_partial_success : bool, optional
+        If True (default), failures to set skim targets for some skim objects
+        (for example due to missing required columns in `df`) will be collected
+        and logged as warnings but will not raise an exception. If False, any
+        such failure will be raised immediately, preventing partial success.
     """
 
     skims = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "requests >= 2.7",
     "scikit-learn >= 1.2",
     "setuptools>=80.9.0",
-    "sharrow >= 2.9.1",
+    "sharrow>=2.15",
     "sparse",
     "tables >= 3.9",  # pytables is tables in pypi
     "xarray >= 2024.05",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -121,7 +121,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.7" },
     { name = "scikit-learn", specifier = ">=1.2" },
     { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "sharrow", specifier = ">=2.9.1" },
+    { name = "sharrow", specifier = ">=2.15" },
     { name = "sparse" },
     { name = "tables", specifier = ">=3.9" },
     { name = "xarray", specifier = ">=2024.5" },
@@ -5051,7 +5051,7 @@ wheels = [
 
 [[package]]
 name = "sharrow"
-version = "2.14.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dask" },
@@ -5066,9 +5066,9 @@ dependencies = [
     { name = "pyarrow" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/ad/9fb609c6cfdd39fb976024fccd2dfa663a5310a4df1a392a80d21605b4cb/sharrow-2.14.0.tar.gz", hash = "sha256:d0d2afadd0b6a9f6c0b3ef6e602262c5f6c31bf33090865db555bae566217df4", size = 2138901, upload-time = "2025-05-29T14:17:12.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/2b/cd163ad3fc6ad48b650cd472bd161f99bcc7cc4befe2b1b04188084c9f9d/sharrow-2.15.0.tar.gz", hash = "sha256:d4e6881f8abfe0719b009963c491285d14c61226c64382ded16b3ce3d6f232fe", size = 2344691, upload-time = "2025-10-31T00:35:35.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/b9/b460fbaf2213f1406d1b5537f50852671e203e1ad92b06d5048f5a132471/sharrow-2.14.0-py3-none-any.whl", hash = "sha256:5879481139297708234f796158b9c81333d01d024aab078452ccd8753de88167", size = 2224745, upload-time = "2025-05-29T14:17:11.543Z" },
+    { url = "https://files.pythonhosted.org/packages/81/93/ff7835535a690a38c9bb3142e3c5b4b2512de09230bf9a20456e6f3db06f/sharrow-2.15.0-py3-none-any.whl", hash = "sha256:8b76bbe1f1ac941711d151cd84b7bc4aec6d2b44d62b56c831ead79eb533aad0", size = 2241380, upload-time = "2025-10-31T00:35:33.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces improvements to error handling and logging in the trip destination model and skim wrapper setup, as well as an update to the minimum required version of the `sharrow` dependency. The main focus is on providing more informative error messages and warnings to help diagnose configuration issues, particularly when using sharrow optimizations.

Note: nothing in this PR is actually needed to solve problems with the SANDAG example running with sharrow -- all the problems are solved by the bug fix in the sharrow 2.15 update.  This PR simply requires we use that fixed dependency, and adds notes about what needs to be done in models when they are not set up correctly for sharrow.

**Error handling and logging improvements:**

* Added a try-except block around the trip destination choice logic in `run_trip_destination` to catch `KeyError` when `purpose_index_num` is missing, logging a detailed error message to guide users on the required configuration for sharrow-optimized runs. [[1]](diffhunk://#diff-217c88f844fe951db363021dd12dd27a9d6bcaf3cf8495f463d8afc82308e460R1498) [[2]](diffhunk://#diff-217c88f844fe951db363021dd12dd27a9d6bcaf3cf8495f463d8afc82308e460R1516-R1531)
* Enhanced the `set_skim_wrapper_targets` function to optionally allow partial success when setting dataframe targets for skims. Now, assertion errors caused by missing required keys are collected and logged as warnings instead of always raising exceptions, improving robustness and debuggability. [[1]](diffhunk://#diff-3b8c25f307a55dd3bdd60b73a025893bc6174504ed67c7ae2702bdd3eac51193L991-R991) [[2]](diffhunk://#diff-3b8c25f307a55dd3bdd60b73a025893bc6174504ed67c7ae2702bdd3eac51193R1018-R1042)

**Dependency update:**

* Increased the minimum required version of the `sharrow` package from `2.9.1` to `2.15` in `pyproject.toml`, ensuring compatibility with recent features and fixes.