### PR TITLE
DOCS: Add front page cards for supported and external model implementations

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -10,5 +10,5 @@ div.sd-card-header {
 }
 
 div.sd-card {
-    margin-bottom: 24px;
+    margin-bottom: 20px;
 }

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -10,5 +10,5 @@ div.sd-card-header {
 }
 
 div.sd-card {
-    margin-bottom: 12px;
+    margin-bottom: 24px;
 }

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -8,3 +8,7 @@ div.sd-card-header {
     font-weight: 800;
     var(--pst-font-family-base);
 }
+
+div.sd-card {
+    margin-bottom: 12px;
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,10 +41,15 @@ the development and management of the ActivitySim is on the `project site <http:
 
         The ActivitySim consortium actively supports two example models:
 
-        - `MTC <https://github.com/ActivitySim/activitysim-prototype-mtc>`__,
-          a one-zone example originally based on MTC's Travel Model One (TM1).
-        - `SANDAG <https://github.com/ActivitySim/sandag-abm3-example>`__,
-          a two-zone example that mirrors SANDAG's ABM3.
+        **`One-Zone <https://github.com/ActivitySim/activitysim-prototype-mtc>`__**
+          Our one-zone example is originally based on MTC's Travel Model One (TM1),
+          but has evolved to be a slightly different model. It is still a reasonable
+          starting point as a donor model for new implementations.
+
+        **`Two Zone <https://github.com/ActivitySim/sandag-abm3-example>`__**
+          Our two-zone example mirrors SANDAG's ABM3. Some effort has been made to
+          keep it aligned with SANDAG's model, but it is not an exact copy of
+          SANDAG's production model.
 
     .. grid-item-card::
 
@@ -53,11 +58,15 @@ the development and management of the ActivitySim is on the `project site <http:
         ^^^
 
         Several consortium member agencies have open-sourced their ActivitySim
-        implementations.  Check out these repositories for more examples:
+        implementations. These open models may or may not be complete calibrated
+        tools that are representative of their respective agencies actual models
+        used for official policy analysis, as public agencies often publish
+        in-progress model development to foster collaboration and transparency.
+        Contact the agencies directly with questions.
 
-        - `Puget Sound Regional Commission <https://github.com/psrc/psrc_activitysim>`__
+        - `Puget Sound Regional Commission <https://github.com/psrc/psrc_activitysim>`__ (Seattle)
         - `Atlanta Regional Commission <https://github.com/atlregional/arc-activitysim>`__
-        - `Metropolitan Council <https://github.com/Metropolitan-Council/metc-asim-model/tree/main/source/activitysim>`__
+        - `Metropolitan Council <https://github.com/Metropolitan-Council/metc-asim-model/tree/main/source/activitysim>`__ (Minneapolis-St. Paul)
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,9 +57,9 @@ the development and management of the ActivitySim is on the `project site <http:
 
         Several consortium member agencies have open-sourced their ActivitySim
         implementations. These open models may or may not be complete calibrated
-        tools that are representative of their respective agencies actual models
-        used for official policy analysis, as public agencies often publish
-        in-progress model development to foster collaboration and transparency.
+        tools. Unless clearly marked, users should not assume that mlinked models are
+        "official" implementations used for policy analysis; public agencies often
+        publish in-progress model development to foster collaboration and transparency.
         Contact the agencies directly with questions.
 
         - `Puget Sound Regional Commission <https://github.com/psrc/psrc_activitysim>`__ (Seattle)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,32 @@ the development and management of the ActivitySim is on the `project site <http:
         Start here to learn about developing ActivitySim, including creating
         model components, or changing the codebase.
 
+    .. grid-item-card::
+
+        :fa:`thumbs-up` |nbsp| |nbsp| Consortium Supported Examples
+
+        ^^^
+
+        The ActivitySim consortium actively supports two example models:
+
+        - `MTC <https://github.com/ActivitySim/activitysim-prototype-mtc>`__,
+          a one-zone example originally based on MTC's Travel Model One (TM1).
+        - `SANDAG <https://github.com/ActivitySim/sandag-abm3-example>`__,
+          a two-zone example that mirrors SANDAG's ABM3.
+
+    .. grid-item-card::
+
+        :fa:`square-arrow-up-right` |nbsp| |nbsp| Member Agency Models
+
+        ^^^
+
+        Several consortium member agencies have open-sourced their ActivitySim
+        implementations.  Check out these repositories for more examples:
+
+        - `Puget Sound Regional Commission <https://github.com/psrc/psrc_activitysim>`__
+        - `Atlanta Regional Commission <https://github.com/atlregional/arc-activitysim>`__
+        - `Metropolitan Council <https://github.com/Metropolitan-Council/metc-asim-model/tree/main/source/activitysim>`__
+
 .. toctree::
    :hidden:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,16 +39,15 @@ the development and management of the ActivitySim is on the `project site <http:
 
         ^^^
 
-        The ActivitySim consortium actively supports two example models:
+        The ActivitySim consortium actively supports two example models, each of which
+        can be used as a starting point (i.e. a "donor model") for new implementations.
 
-        - `MTC Example <https://github.com/ActivitySim/activitysim-prototype-mtc>`__,
-          our one-zone system prototype is originally based on MTC's Travel Model One (TM1),
-          but has evolved to be a slightly different model. It is still a reasonable
-          starting point as a donor model for new implementations.
-        - `SANDAG Example <https://github.com/ActivitySim/sandag-abm3-example>`__,
-          our two-zone system model mirrors the typical resident portion of SANDAG's
-          ABM3. Some effort has been made to keep it aligned with SANDAG's model, but
-          it is not an exact copy of SANDAG's production model.
+        - The `MTC Example <https://github.com/ActivitySim/activitysim-prototype-mtc>`__,
+          our one-zone system prototype. This example is originally based on MTC's Travel Model One (TM1),
+          but has evolved to be a slightly different model.
+        - The `SANDAG Example <https://github.com/ActivitySim/sandag-abm3-example>`__,
+          our two-zone system model. Some effort has been made to keep it aligned
+          with SANDAG's model, but it is not an exact copy of SANDAG's production model.
 
     .. grid-item-card::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ the development and management of the ActivitySim is on the `project site <http:
         - `Puget Sound Regional Commission <https://github.com/psrc/psrc_activitysim>`__ (Seattle)
         - `Atlanta Regional Commission <https://github.com/atlregional/arc-activitysim>`__
         - `Metropolitan Council <https://github.com/Metropolitan-Council/metc-asim-model/tree/main/source/activitysim>`__ (Minneapolis-St. Paul)
+        - `Oregon Modeling Statewide Collaborative <https://github.com/OrMSC/SimOR>`__
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,15 +41,14 @@ the development and management of the ActivitySim is on the `project site <http:
 
         The ActivitySim consortium actively supports two example models:
 
-        **`One-Zone <https://github.com/ActivitySim/activitysim-prototype-mtc>`__**
-          Our one-zone example is originally based on MTC's Travel Model One (TM1),
+        - `MTC Example <https://github.com/ActivitySim/activitysim-prototype-mtc>`__,
+          our one-zone system prototype is originally based on MTC's Travel Model One (TM1),
           but has evolved to be a slightly different model. It is still a reasonable
           starting point as a donor model for new implementations.
-
-        **`Two Zone <https://github.com/ActivitySim/sandag-abm3-example>`__**
-          Our two-zone example mirrors SANDAG's ABM3. Some effort has been made to
-          keep it aligned with SANDAG's model, but it is not an exact copy of
-          SANDAG's production model.
+        - `SANDAG Example <https://github.com/ActivitySim/sandag-abm3-example>`__,
+          our two-zone system model mirrors the typical resident portion of SANDAG's
+          ABM3. Some effort has been made to keep it aligned with SANDAG's model, but
+          it is not an exact copy of SANDAG's production model.
 
     .. grid-item-card::
 


### PR DESCRIPTION
This pull request updates the documentation and styling to improve clarity and accessibility for users exploring ActivitySim models. The main changes introduce new documentation cards highlighting example models and member agency implementations, and a minor CSS tweak for improved layout.

**Documentation enhancements:**

* Added two new grid-item cards to `docs/index.rst`:
  * One card highlights consortium-supported example models (MTC and SANDAG), providing direct links and descriptions for each.
  * Another card lists open-source ActivitySim implementations from member agencies, with links and context about their status and usage.