### PR TITLE
Fix trace IDs so they have the same hash

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -130,6 +130,7 @@ jobs:
 
       - run: uv run pytest test/test_skim_name_conflicts.py
       - run: uv run pytest test/random_seed/test_random_seed.py
+      - run: uv run pytest test/trace_id/test_trace_id.py
 
   builtin_regional_models:
     needs: foundation

--- a/activitysim/cli/run.py
+++ b/activitysim/cli/run.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from activitysim.core import chunk, config, mem, timing, tracing, workflow
 from activitysim.core.configuration import FileSystem, Settings
+from activitysim.core.run_id import RunId
 
 from activitysim.abm.models.settings_checker import check_model_settings
 
@@ -33,14 +34,6 @@ INJECTABLES = [
     "run_timestamp",
     "run_id",
 ]
-
-class RunId(str):
-    def __new__(cls, x=None):
-        if x is None:
-            return cls(
-                hex(struct.unpack("<Q", struct.pack("<d", time.time()))[0])[-6:].lower()
-            )
-        return super().__new__(cls, x)
 
 
 def add_run_args(parser, multiprocess=True):
@@ -172,7 +165,7 @@ def handle_standard_args(state: workflow.State, args, multiprocess=True):
         # 'configs', 'data', and 'output' folders by default
         os.chdir(args.working_dir)
 
-    inject_arg("run_id", state.run_id)
+    inject_arg("run_id", state.tracing.run_id)
 
     if args.ext:
         for e in args.ext:
@@ -281,7 +274,7 @@ def run(args):
     """
 
     state = workflow.State()
-    state.run_id = RunId()
+    _init_run_id = state.tracing.run_id
 
     # register abm steps and other abm-specific injectables
     # by default, assume we are running activitysim.abm

--- a/activitysim/core/configuration/top.py
+++ b/activitysim/core/configuration/top.py
@@ -791,10 +791,3 @@ class Settings(PydanticBase, extra="allow", validate_assignment=True):
         except AttributeError:
             return self.other_settings.get(attr)
 
-class RunId(str):
-    def __new__(cls, x=None):
-        if x is None:
-            return cls(
-                hex(struct.unpack("<Q", struct.pack("<d", time.time()))[0])[-6:].lower()
-            )
-        return super().__new__(cls, x)

--- a/activitysim/core/configuration/top.py
+++ b/activitysim/core/configuration/top.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Literal
+import struct
+import time
 
 from pydantic import model_validator, validator
 
@@ -788,3 +790,11 @@ class Settings(PydanticBase, extra="allow", validate_assignment=True):
             return getattr(self, attr)
         except AttributeError:
             return self.other_settings.get(attr)
+
+class RunId(str):
+    def __new__(cls, x=None):
+        if x is None:
+            return cls(
+                hex(struct.unpack("<Q", struct.pack("<d", time.time()))[0])[-6:].lower()
+            )
+        return super().__new__(cls, x)

--- a/activitysim/core/configuration/top.py
+++ b/activitysim/core/configuration/top.py
@@ -790,4 +790,3 @@ class Settings(PydanticBase, extra="allow", validate_assignment=True):
             return getattr(self, attr)
         except AttributeError:
             return self.other_settings.get(attr)
-

--- a/activitysim/core/mp_tasks.py
+++ b/activitysim/core/mp_tasks.py
@@ -19,6 +19,7 @@ import yaml
 
 from activitysim.core import config, mem, tracing, util, workflow
 from activitysim.core.configuration import FileSystem, Settings
+from activitysim.core.run_id import RunId
 from activitysim.core.workflow.checkpoint import (
     CHECKPOINT_NAME,
     CHECKPOINT_TABLE_NAME,
@@ -890,7 +891,10 @@ def setup_injectables_and_logging(injectables, locutor: bool = True) -> workflow
     injects injectables
     """
     state = workflow.State()
-    state.run_id = injectables.get("run_id", None)
+    _run_id = injectables.get("run_id", None)
+    if _run_id:
+        state.tracing.run_id = RunId(_run_id)
+
     state = state.initialize_filesystem(**injectables)
     state.settings = injectables.get("settings", Settings())
     state.filesystem.parse_settings(state.settings)

--- a/activitysim/core/mp_tasks.py
+++ b/activitysim/core/mp_tasks.py
@@ -885,6 +885,7 @@ def setup_injectables_and_logging(injectables, locutor: bool = True) -> workflow
     injects injectables
     """
     state = workflow.State()
+    state.run_id = injectables.get("run_id", None)
     state = state.initialize_filesystem(**injectables)
     state.settings = injectables.get("settings", Settings())
     state.filesystem.parse_settings(state.settings)

--- a/activitysim/core/run_id.py
+++ b/activitysim/core/run_id.py
@@ -1,6 +1,7 @@
 import struct
 import time
 
+
 class RunId(str):
     def __new__(cls, x=None):
         if x is None:

--- a/activitysim/core/run_id.py
+++ b/activitysim/core/run_id.py
@@ -1,0 +1,10 @@
+import struct
+import time
+
+class RunId(str):
+    def __new__(cls, x=None):
+        if x is None:
+            return cls(
+                hex(struct.unpack("<Q", struct.pack("<d", time.time()))[0])[-6:].lower()
+            )
+        return super().__new__(cls, x)

--- a/activitysim/core/workflow/state.py
+++ b/activitysim/core/workflow/state.py
@@ -110,7 +110,7 @@ class State:
     The encapsulated state of an ActivitySim model.
     """
 
-    def __init__(self, context=None, run_id = None):
+    def __init__(self, context=None):
         """
         Initialize the encapsulated state of an ActivitySim model.
 
@@ -130,12 +130,6 @@ class State:
             self._context = context
         else:
             raise TypeError(f"cannot init {type(self)} with {type(context)}")
-        
-        self.run_id = run_id
-
-    @property
-    def run_id(self):
-        return self.run_id
 
     def __del__(self):
         self.close_open_files()
@@ -259,7 +253,7 @@ class State:
 
     checkpoint = Checkpoints()
     logging = Logging()
-    tracing = Tracing(run_id)
+    tracing = Tracing()
     extend = Extend()
     report = Reporting()
     dataset = Datasets()

--- a/activitysim/core/workflow/state.py
+++ b/activitysim/core/workflow/state.py
@@ -258,7 +258,6 @@ class State:
     report = Reporting()
     dataset = Datasets()
     chunk = Chunking()
-    run_id = None # To be initialized when the run starts
 
     @property
     def this_step(self):

--- a/activitysim/core/workflow/state.py
+++ b/activitysim/core/workflow/state.py
@@ -258,6 +258,7 @@ class State:
     report = Reporting()
     dataset = Datasets()
     chunk = Chunking()
+    run_id = None # To be initialized when the run starts
 
     @property
     def this_step(self):

--- a/activitysim/core/workflow/state.py
+++ b/activitysim/core/workflow/state.py
@@ -110,7 +110,7 @@ class State:
     The encapsulated state of an ActivitySim model.
     """
 
-    def __init__(self, context=None):
+    def __init__(self, context=None, run_id = None):
         """
         Initialize the encapsulated state of an ActivitySim model.
 
@@ -130,6 +130,12 @@ class State:
             self._context = context
         else:
             raise TypeError(f"cannot init {type(self)} with {type(context)}")
+        
+        self.run_id = run_id
+
+    @property
+    def run_id(self):
+        return self.run_id
 
     def __del__(self):
         self.close_open_files()
@@ -253,7 +259,7 @@ class State:
 
     checkpoint = Checkpoints()
     logging = Logging()
-    tracing = Tracing()
+    tracing = Tracing(run_id)
     extend = Extend()
     report = Reporting()
     dataset = Datasets()

--- a/activitysim/core/workflow/tracing.py
+++ b/activitysim/core/workflow/tracing.py
@@ -35,6 +35,7 @@ DEFAULT_TRACEABLE_TABLES = [
     "vehicles",
 ]
 
+
 class Tracing(StateAccessor):
     """
     Methods to provide the tracing capabilities of ActivitySim.

--- a/activitysim/core/workflow/tracing.py
+++ b/activitysim/core/workflow/tracing.py
@@ -20,6 +20,7 @@ from activitysim.core import tracing
 from activitysim.core.test import assert_equal, assert_frame_substantively_equal
 from activitysim.core.workflow.accessor import FromState, StateAccessor
 from activitysim.core.exceptions import TableSlicingError
+from activitysim.core.run_id import RunId
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ class Tracing(StateAccessor):
     traceable_tables: list[str] = FromState(default_value=DEFAULT_TRACEABLE_TABLES)
     traceable_table_ids: dict[str, Sequence] = FromState(default_init=True)
     traceable_table_indexes: dict[str, str] = FromState(default_init=True)
-    # run_id: RunId = FromState(default_init=True)
+    run_id: RunId = FromState(default_init=True)
 
     @property
     def validation_directory(self) -> Path | None:
@@ -241,7 +242,7 @@ class Tracing(StateAccessor):
             file_name = "%s.%s" % (file_name, CSV_FILE_TYPE)
 
         file_path = self._obj.filesystem.get_trace_file_path(
-            file_name, tail=self._obj.run_id
+            file_name, tail=self.run_id
         )
 
         if os.name == "nt":
@@ -367,7 +368,7 @@ class Tracing(StateAccessor):
 
                         that_blob = read_csv_as_list_of_lists(that_path)
                         this_path = self._obj.filesystem.get_trace_file_path(
-                            label, tail=self._obj.run_id, file_type="csv"
+                            label, tail=self.run_id, file_type="csv"
                         )
                         this_blob = read_csv_as_list_of_lists(this_path)
 
@@ -399,7 +400,7 @@ class Tracing(StateAccessor):
                         that_df = pd.read_csv(that_path)
                         # check against the file we just wrote
                         this_path = self._obj.filesystem.get_trace_file_path(
-                            label, tail=self._obj.run_id, file_type="csv"
+                            label, tail=self.run_id, file_type="csv"
                         )
                         this_df = pd.read_csv(this_path)
                         assert_frame_substantively_equal(this_df, that_df)
@@ -441,7 +442,7 @@ class Tracing(StateAccessor):
         # write out the raw dataframe
 
         file_path = self._obj.filesystem.get_trace_file_path(
-            "%s.raw.csv" % label, tail=self._obj.run_id
+            "%s.raw.csv" % label, tail=self.run_id
         )
         trace_results.to_csv(file_path, mode="a", index=True, header=True)
 

--- a/activitysim/core/workflow/tracing.py
+++ b/activitysim/core/workflow/tracing.py
@@ -50,10 +50,22 @@ class Tracing(StateAccessor):
     Methods to provide the tracing capabilities of ActivitySim.
     """
 
+    def __init__(self, run_id = None):
+        super().__init__()
+        if run_id is None:
+            run_id = RunId()
+        self.run_id = run_id
+
     traceable_tables: list[str] = FromState(default_value=DEFAULT_TRACEABLE_TABLES)
     traceable_table_ids: dict[str, Sequence] = FromState(default_init=True)
     traceable_table_indexes: dict[str, str] = FromState(default_init=True)
-    run_id: RunId = FromState(default_init=True)
+
+    @property
+    def run_id(self) -> RunId:
+        if self._obj is None:
+            return RunId()
+        else:
+            return self.run_id
 
     @property
     def validation_directory(self) -> Path | None:

--- a/activitysim/core/workflow/tracing.py
+++ b/activitysim/core/workflow/tracing.py
@@ -50,22 +50,10 @@ class Tracing(StateAccessor):
     Methods to provide the tracing capabilities of ActivitySim.
     """
 
-    def __init__(self, run_id = None):
-        super().__init__()
-        if run_id is None:
-            run_id = RunId()
-        self.run_id = run_id
-
     traceable_tables: list[str] = FromState(default_value=DEFAULT_TRACEABLE_TABLES)
     traceable_table_ids: dict[str, Sequence] = FromState(default_init=True)
     traceable_table_indexes: dict[str, str] = FromState(default_init=True)
-
-    @property
-    def run_id(self) -> RunId:
-        if self._obj is None:
-            return RunId()
-        else:
-            return self.run_id
+    run_id: RunId = FromState(default_init=True)
 
     @property
     def validation_directory(self) -> Path | None:

--- a/test/trace_id/.gitignore
+++ b/test/trace_id/.gitignore
@@ -1,0 +1,2 @@
+configs*/
+output/

--- a/test/trace_id/simulation.py
+++ b/test/trace_id/simulation.py
@@ -1,0 +1,16 @@
+# ActivitySim
+# See full license in LICENSE.txt.
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from activitysim.cli.run import add_run_args, run
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    add_run_args(parser)
+    args = parser.parse_args()
+
+    sys.exit(run(args))

--- a/test/trace_id/test_trace_id.py
+++ b/test/trace_id/test_trace_id.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+# ActivitySim
+# See full license in LICENSE.txt.
+import importlib.resources
+import os
+import subprocess
+from shutil import copytree
+
+import pandas as pd
+import pandas.testing as pdt
+import yaml
+
+def update_settings(settings_file, key, value):
+    with open(settings_file, "r") as f:
+        settings = yaml.safe_load(f)
+        f.close()
+
+    settings[key] = value
+
+    with open(settings_file, "w") as f:
+        yaml.safe_dump(settings, f)
+        f.close()
+
+def run_test_trace_id():
+
+    def example_path(dirname):
+        resource = os.path.join("examples", "prototype_mtc", dirname)
+        return str(importlib.resources.files("activitysim").joinpath(resource))
+
+    def test_path(dirname):
+        return os.path.join(os.path.dirname(__file__), dirname)
+    
+    new_configs_dir = test_path("configs")
+    new_mp_configs_dir = test_path("configs_mp")
+    new_settings_file = os.path.join(new_configs_dir, "settings.yaml")
+    copytree(example_path("configs"), new_configs_dir)
+    copytree(example_path("configs_mp"), new_mp_configs_dir)
+
+    update_settings(new_settings_file, "trace_hh_id", 1932009) # Household in the prototype_mtc example with 11 people
+
+    def check_csv_suffix(directory):
+        suffix = None
+        mismatched_files = []
+        for root, dirs, files in os.walk(directory):
+            for filename in files:
+                if filename.lower().endswith('.csv'):
+                    file_suffix = filename[-10:]
+                    if suffix is None:
+                        suffix = file_suffix
+                    elif file_suffix != suffix:
+                        mismatched_files.append(os.path.join(root, filename))
+        if mismatched_files:
+            raise AssertionError(f"CSV files with mismatched suffixes: {mismatched_files}")
+         
+    file_path = os.path.join(os.path.dirname(__file__), "simulation.py")
+
+    run_args = [
+        "-c",
+        test_path("configs_mp"),
+        "-c",
+        test_path("configs"),
+        "-d",
+        example_path("data"),
+        "-o",
+        test_path("output"),
+    ]
+    
+    try:
+        os.mkdir(test_path("output"))
+    except FileExistsError:
+        pass
+
+    subprocess.run(["coverage", "run", "-a", file_path] + run_args, check=True)
+
+    check_csv_suffix(os.path.join(test_path("output"), "trace"))
+
+if __name__ == "__main__":
+    run_test_trace_id()

--- a/test/trace_id/test_trace_id.py
+++ b/test/trace_id/test_trace_id.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pandas.testing as pdt
 import yaml
 
+
 def update_settings(settings_file, key, value):
     with open(settings_file, "r") as f:
         settings = yaml.safe_load(f)
@@ -22,37 +23,41 @@ def update_settings(settings_file, key, value):
         yaml.safe_dump(settings, f)
         f.close()
 
-def test_trace_ids_have_same_hash():
 
+def test_trace_ids_have_same_hash():
     def example_path(dirname):
         resource = os.path.join("examples", "prototype_mtc", dirname)
         return str(importlib.resources.files("activitysim").joinpath(resource))
 
     def test_path(dirname):
         return os.path.join(os.path.dirname(__file__), dirname)
-    
+
     new_configs_dir = test_path("configs")
     new_mp_configs_dir = test_path("configs_mp")
     new_settings_file = os.path.join(new_configs_dir, "settings.yaml")
     copytree(example_path("configs"), new_configs_dir)
     copytree(example_path("configs_mp"), new_mp_configs_dir)
 
-    update_settings(new_settings_file, "trace_hh_id", 1932009) # Household in the prototype_mtc example with 11 people
+    update_settings(
+        new_settings_file, "trace_hh_id", 1932009
+    )  # Household in the prototype_mtc example with 11 people
 
     def check_csv_suffix(directory):
         suffix = None
         mismatched_files = []
         for root, dirs, files in os.walk(directory):
             for filename in files:
-                if filename.lower().endswith('.csv'):
+                if filename.lower().endswith(".csv"):
                     file_suffix = filename[-10:]
                     if suffix is None:
                         suffix = file_suffix
                     elif file_suffix != suffix:
                         mismatched_files.append(os.path.join(root, filename))
         if mismatched_files:
-            raise AssertionError(f"CSV files with mismatched suffixes: {mismatched_files}")
-         
+            raise AssertionError(
+                f"CSV files with mismatched suffixes: {mismatched_files}"
+            )
+
     file_path = os.path.join(os.path.dirname(__file__), "simulation.py")
 
     run_args = [
@@ -65,7 +70,7 @@ def test_trace_ids_have_same_hash():
         "-o",
         test_path("output"),
     ]
-    
+
     try:
         os.mkdir(test_path("output"))
     except FileExistsError:
@@ -74,6 +79,7 @@ def test_trace_ids_have_same_hash():
     subprocess.run(["coverage", "run", "-a", file_path] + run_args, check=True)
 
     check_csv_suffix(os.path.join(test_path("output"), "trace"))
+
 
 if __name__ == "__main__":
     test_trace_ids_have_same_hash()

--- a/test/trace_id/test_trace_id.py
+++ b/test/trace_id/test_trace_id.py
@@ -22,7 +22,7 @@ def update_settings(settings_file, key, value):
         yaml.safe_dump(settings, f)
         f.close()
 
-def run_test_trace_id():
+def test_trace_ids_have_same_hash():
 
     def example_path(dirname):
         resource = os.path.join("examples", "prototype_mtc", dirname)
@@ -76,4 +76,4 @@ def run_test_trace_id():
     check_csv_suffix(os.path.join(test_path("output"), "trace"))
 
 if __name__ == "__main__":
-    run_test_trace_id()
+    test_trace_ids_have_same_hash()


### PR DESCRIPTION
This pull request changes the code so that only one Run ID will be generated for the entire model run, and not just for each subprocess. This is being done by adding a module in the core directory called run_id.py that defines a `RunID` object. This is then read in by every `state` object that is generated. As a result, any tracing files for a single run will all have the same hash, which will solve Issue #899.