### PR TITLE
select correct branch for latest 1-zone example

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -211,7 +211,7 @@ jobs:
           - region: Standard 1-Zone Example (MTC)
             region-org: ActivitySim
             region-repo: activitysim-prototype-mtc
-            region-branch: pandas2
+            region-branch: extended
           - region: Standard 2-Zone Example (SANDAG)
             region-org: ActivitySim
             region-repo: sandag-abm3-example
@@ -355,14 +355,14 @@ jobs:
 
       - name: Create Estimation Data
         run: >
-          uv run python activitysim/examples/example_estimation/notebooks/est_mode_setup.py 
+          uv run python activitysim/examples/example_estimation/notebooks/est_mode_setup.py
           --household_sample_size 5000
 
       - name: Test Estimation Notebooks
         run: >
-          uv run pytest activitysim/examples/example_estimation/notebooks 
-          --nbmake-timeout=3000 
-          --ignore=activitysim/examples/example_estimation/notebooks/01_estimation_mode.ipynb 
+          uv run pytest activitysim/examples/example_estimation/notebooks
+          --nbmake-timeout=3000
+          --ignore=activitysim/examples/example_estimation/notebooks/01_estimation_mode.ipynb
           --ignore-glob=activitysim/examples/example_estimation/notebooks/test-estimation-data/**
 
   estimation_edb_creation:


### PR DESCRIPTION
This pull request updates the configuration for the core tests workflow by changing the branch used for the "Standard 1-Zone Example (MTC)" test region. The test now uses the `extended` branch instead of the `pandas2` branch.

- Workflow configuration update:
  * [`.github/workflows/core_tests.yml`](diffhunk://#diff-8cf10f64f5a7c43b261826c052e9e468e7a0f8e75d2946c0f48dbfaeaa748545L214-R214): Updated the `region-branch` for the "Standard 1-Zone Example (MTC)" test from `pandas2` to `extended`.