### PR TITLE
Implement deletion of temporary variables in summarize.py

### DIFF
--- a/activitysim/abm/models/summarize.py
+++ b/activitysim/abm/models/summarize.py
@@ -364,6 +364,15 @@ def summarize(
         out_file = row["Output"]
         expr = row["Expression"]
 
+        # delete temporary variables starting with '_del' from locals_d
+        if out_file == "_del":
+            logger.debug(f"Deleting temporary variable: {expr}")
+            with performance_timer.time_expression(expr):
+                exec(f"del {expr}", globals(), locals_d)
+                for var in expr.split(","):
+                    locals_d.pop(var.strip(), None)
+            continue
+
         # Save temporary variables starting with underscores in locals_d
         if out_file.startswith("_"):
             logger.debug(f"Temp Variable: {expr} -> {out_file}")


### PR DESCRIPTION
While running the summarise step I ran into memory allocation issues.
I tested adding the deletion of temporary variables not used in subsequent summaries and managed to go through the step.