### PR TITLE
Remove Sample Rate Rounding

### DIFF
--- a/activitysim/abm/tables/households.py
+++ b/activitysim/abm/tables/households.py
@@ -99,10 +99,7 @@ def households(state: workflow.State) -> pd.DataFrame:
         if households_sample_size == 0:
             sample_rate = 1
         else:
-            # TODO: do not round, keep full precision to avoid creating 0 sample_rate for small samples
-            # Existing CI tests will fail when performing bitwise comparisons with the unrounded sample_rate
-            # We should update the CI tests
-            sample_rate = round(households_sample_size / tot_households, 3)
+            sample_rate = households_sample_size / tot_households
 
         df["sample_rate"] = sample_rate
 

--- a/activitysim/abm/test/test_misc/test_sample_rate.py
+++ b/activitysim/abm/test/test_misc/test_sample_rate.py
@@ -1,0 +1,55 @@
+# ActivitySim
+# See full license in LICENSE.txt.
+import pandas as pd
+
+import pytest
+
+from activitysim.core import workflow
+
+
+@pytest.fixture(scope="session")
+def example_root(tmp_path_factory):
+    root = tmp_path_factory.mktemp("example")
+    config_dir = root / "configs"
+    config_dir.mkdir()
+
+    data_dir = root / "data"
+    data_dir.mkdir()
+
+    return root
+
+
+@pytest.fixture(scope="module")
+def state(example_root) -> workflow.State:
+
+    settings = """
+        input_table_list:
+            - tablename: households
+              filename: households.csv
+              index_col: household_id
+        
+        households_sample_size: 2
+        """
+
+    settings_file = example_root / "configs" / "settings.yaml"
+    settings_file.write_text(settings)
+
+    households = pd.DataFrame(
+        {
+            "household_id": range(1, 100001),
+            "home_zone_id": [1, 2] * 50000,
+        }
+    )
+    households.to_csv(example_root / "data" / "households.csv", index=False)
+
+    state = workflow.State.make_default(example_root)
+
+    return state
+
+
+def test_sample_rate_calculation(state):
+    households_df = state.get_dataframe("households")
+    sample_rate = households_df["sample_rate"].iloc[0]
+    assert (
+        sample_rate == 0.00002
+    ), f"Expected sample rate of 0.00002, but got {sample_rate}"

--- a/activitysim/abm/test/test_misc/test_sample_rate.py
+++ b/activitysim/abm/test/test_misc/test_sample_rate.py
@@ -36,8 +36,8 @@ def state(example_root) -> workflow.State:
 
     households = pd.DataFrame(
         {
-            "household_id": range(1, 100001),
-            "home_zone_id": [1, 2] * 50000,
+            "household_id": range(1, 4002),
+            "home_zone_id": [1, 2] * 2000 + [1],
         }
     )
     households.to_csv(example_root / "data" / "households.csv", index=False)
@@ -50,6 +50,6 @@ def state(example_root) -> workflow.State:
 def test_sample_rate_calculation(state):
     households_df = state.get_dataframe("households")
     sample_rate = households_df["sample_rate"].iloc[0]
-    assert (
-        sample_rate == 0.00002
-    ), f"Expected sample rate of 0.00002, but got {sample_rate}"
+    assert sample_rate == pytest.approx(
+        0.0005, abs=1e-6
+    ), f"Expected sample rate of 0.0005, but got {sample_rate}"


### PR DESCRIPTION
This pull request makes a small but important change to the calculation of `sample_rate` in the `households` table logic. Instead of rounding `sample_rate` to three decimal places, which can result in a value of 0 for small sample sizes, the code now preserves the full precision of the division. This ensures meaningful values (not NaN or Inf) in trip matrices that use the inverse of the sample rate in their calculations.

**Code changes**: a simple change in the `households.py`.

**Test updates**: 
- updated the `sample_rate` target values to full precision in the failed SANDAG tests. https://github.com/ActivitySim/sandag-abm3-example/pull/42
- added a unit test for `sample_rate` calculation.