### PR TITLE
stop publishing to test.pypi

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -66,14 +66,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install dist/activitysim*.whl
           python -m activitysim --version
-      - name: Publish package to TestPyPI
-        if: github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          verbose: true
 
   docbuild:
     needs: test-built-dist

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -70,11 +70,3 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install dist/activitysim*.whl
           python -m activitysim --version
-      - name: Publish package to TestPyPI
-        if: github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          verbose: true


### PR DESCRIPTION
This pull request removes the step that publishes the package to TestPyPI from both the deployment and test deployment GitHub Actions workflows. This change prevents automatic uploads to TestPyPI, which is full of old ActivitySim junk but due to security protections cannot be easily cleaned out.

Workflow updates:

* Removed the "Publish package to TestPyPI" step from the deployment workflow in `.github/workflows/deployment.yml`.
* Removed the "Publish package to TestPyPI" step from the test deployment workflow in `.github/workflows/test-deploy.yml`.